### PR TITLE
Add Jest test framework

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 .eslintrc.js
+jest.config.js

--- a/client/package.json
+++ b/client/package.json
@@ -95,6 +95,7 @@
     ]
   },
   "scripts": {
+    "test": "npm run test:grammar",
     "test:grammar": "vscode-tmgrammar-test ./test/grammars/test-cases/*.bb",
     "snap-grammar": "vscode-tmgrammar-snap ./test/grammars/snaps/*.bb -u"
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,31 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  clearMocks: true,
+  moduleFileExtensions: [
+    "js",
+    "json",
+    "ts"
+  ],
+  modulePathIgnorePatterns: [
+    "<rootDir>/server/out",
+    "<rootDir>/client/out"
+  ],
+  transform: {
+    "\\.ts$": [
+      "ts-jest",
+      {
+        "tsconfig": "./server/tsconfig.json"
+      }
+    ]
+  },
+  testMatch: [
+    "<rootDir>/**/__tests__/*.ts"
+  ],
+  collectCoverageFrom: [
+    "**/*.ts",
+    "!**/__test__/*",
+    "!testing/*"
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -30,17 +30,21 @@
 		"clean:server": "rm -fr ./server/node_modules && rm -fr ./server/out",
 		"clean:client": "rm -fr ./client/node_modules && rm -fr ./client/out",
 		"clean": "npm run clean:server && npm run clean:client && rm -fr node_modules",
-		"lint": "eslint . --ext js,ts --cache"
+		"lint": "eslint . --ext js,ts --cache",
+		"test": "jest && npm run test --workspace client",
+		"test:watch": "jest --watchAll"
 	},
 	"devDependencies": {
+		"@types/jest": "^29.5.5",
 		"@types/node": "^20.6.1",
 		"eslint": "^8.51.0",
 		"eslint-config-standard-with-typescript": "^39.1.1",
 		"eslint-plugin-import": "^2.28.1",
 		"eslint-plugin-n": "^16.2.0",
 		"eslint-plugin-promise": "^6.1.1",
-		"@typescript-eslint/eslint-plugin": "^5.54.0",
-		"@typescript-eslint/parser": "^5.54.0",
+		"eslint-plugin-jest": "^27.4.2",
+		"jest": "^29.7.0",
+		"ts-jest": "^29.1.1",
 		"typescript": "^5.1.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
 		"lint": "eslint . --ext js,ts --cache"
 	},
 	"devDependencies": {
-		"@types/mocha": "^10.0.1",
 		"@types/node": "^20.6.1",
 		"eslint": "^8.51.0",
 		"eslint-config-standard-with-typescript": "^39.1.1",
 		"eslint-plugin-import": "^2.28.1",
 		"eslint-plugin-n": "^16.2.0",
 		"eslint-plugin-promise": "^6.1.1",
-		"mocha": "^10.2.0",
+		"@typescript-eslint/eslint-plugin": "^5.54.0",
+		"@typescript-eslint/parser": "^5.54.0",
 		"typescript": "^5.1.3"
 	}
 }

--- a/server/src/__tests__/test.test.ts
+++ b/server/src/__tests__/test.test.ts
@@ -1,0 +1,3 @@
+test('two plus two is four', () => {
+  expect(2 + 2).toBe(4)
+})


### PR DESCRIPTION
Removed mocha library and added Jest.
Most settings are from `bash-language-server`.
Added a `test.test.ts` for verifying the functionality.

In order to have a complete test suite for this **TS** project. we seem to need additional libraries.