### PR TITLE
Use path, fs from @types/node

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,8 +20,6 @@
   },
   "dependencies": {
     "find": "^0.2.7",
-    "fs": "0.0.1-security",
-    "path": "^0.12.7",
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8",
     "web-tree-sitter": "^0.20.8",


### PR DESCRIPTION
Seems like the files automatically include the `path` and `fs` from `@types/node` at root `package.json`. So I don't think the obsolete ones from server `package.json` are actually used. ~~However, I didn't find a good replacement for `find`, so I used the `readdir` from `fs` to achieve the similar results.~~