### PR TITLE
Chore: Add the setting to auto fix eslint errors on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
 		"out": true // set this to false to include "out" folder in search results
 	},
 	"typescript.tsdk": "./node_modules/typescript/lib",
-	"typescript.tsc.autoDetect": "off"
+	"typescript.tsc.autoDetect": "off",
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": true
+	}
 }


### PR DESCRIPTION
This setting enables auto fix for eslint errors on save