### PR TITLE
Fix: SymbolScanner fail to read URLs  on Windows

### DIFF
--- a/server/src/SymbolScanner.ts
+++ b/server/src/SymbolScanner.ts
@@ -73,10 +73,13 @@ export class SymbolScanner {
         }
       }
     } catch (error) {
-      if (typeof error !== 'string') {
-        throw error
+      if (error instanceof Error) { // Check if error is an instance of the native JavaScript Error class
+        logger.error(`Error reading file at ${filePath}: ${error.message}`)
+      } else if (typeof error === 'string') {
+        logger.error(`Error reading file at ${filePath}: ${error}`)
+      } else {
+        logger.error(`An unknown error occurred while reading the file at ${filePath}`)
       }
-      logger.error(`can not open file error: ${error}`)
     }
   }
 
@@ -119,7 +122,14 @@ export class SymbolScanner {
 
   private convertUriStringToFilePath (fileUrlAsString: string): string {
     const fileUrl = new URL(fileUrlAsString)
-    const filePath: string = decodeURI(fileUrl.pathname)
+    // Use decodeURIComponent to properly decode each part of the URL
+    // This correctly decodes url in Windows such as %3A -> :
+    let filePath: string = decodeURIComponent(fileUrl.pathname)
+
+    // For Windows, remove the leading slash if it exists
+    if (process.platform === 'win32' && filePath.startsWith('/')) {
+      filePath = filePath.substring(1)
+    }
 
     return filePath
   }


### PR DESCRIPTION
I encountered a read file error on Windows, so I made the following changes:
1. Remove the `throw` in the `catch` block because the upper call stack doesn't handle it. 
2. Use `decodeURIComponent` to decode URLs. This will correctly decode Windows URLs (e.g. `d%3A/folder` -> `d:/folder`)

From my understanding of this SymbolScanner, some functionalities could be moved to the Analyzer (tree-sitter). For now, let's keep it as is.