### PR TITLE
Chore: Add request to verify conf files association

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -218,6 +218,11 @@ documents.onDidChangeContent(async (event) => {
   const diagnostics = await analyzer.analyze({ document: event.document, uri: event.document.uri })
 
   void connection.sendDiagnostics({ uri: textDocument.uri, diagnostics })
+
+  if (textDocument.uri.endsWith('.conf')) {
+    logger.debug('verifyConfigurationFileAssociation')
+    await connection.sendRequest('custom/verifyConfigurationFileAssociation', { filePath: new URL(textDocument.uri).pathname })
+  }
 })
 
 documents.onDidClose((event) => {


### PR DESCRIPTION
The `.conf` files should always be associated with `bitbake` language mode as long as there is no other extension causing the conflict. Currently, this extension is known to cause such conflict: [Txt Syntax](https://github.com/xshrim/vscode-txt-syntax/blob/3e5851b4a4eaf6a0e5fc5281fa29f1f68cd5d591/src/extension.js#L103)

I prefer to let users be aware of this situation rather than attempting to compete against another extension to set the language mode. 