### PR TITLE
Fix: (\") breaks the highlighting inside the string & broken grammar rule related to []

### DIFF
--- a/client/syntaxes/bitbake.tmLanguage.json
+++ b/client/syntaxes/bitbake.tmLanguage.json
@@ -13,11 +13,6 @@
             "include": "#string"
         },
         {
-            "begin": "(?<=\\[)",
-            "end": "(?=\\])",
-            "name": "source.python"
-        },
-        {
             "include": "#numeric"
         },
         {
@@ -113,6 +108,10 @@
                     "begin": "(\")",
                     "end": "(\")",
                     "patterns": [
+                        {
+                            "match": "\\\\\"",
+                            "name": "constant.character.escape.bb"
+                        },
                         {
                             "include": "#variable-reference"
                         }

--- a/client/test/grammars/snaps/strings.bb
+++ b/client/test/grammars/snaps/strings.bb
@@ -44,3 +44,5 @@ python () {
 inherit ${@ 'classname' if condition else ''}
 
 INHERIT += "autotools pkgconfig"
+
+MYVAR = "This string contains literal \" and it should work"

--- a/client/test/grammars/test-cases/nested-patterns.bb
+++ b/client/test/grammars/test-cases/nested-patterns.bb
@@ -60,7 +60,7 @@
 #                                               ^ source.bb keyword.operator.bb
 #                                                ^ source.bb variable.other.names.bb
 #                                                 ^^ source.bb
-#                                                   ^ source.bb source.python
+#                                                   ^ source.bb constant.numeric.bb
 #                                                    ^^ source.bb
  
 >python myclass_eventhandler() {

--- a/client/test/grammars/test-cases/strings.bb
+++ b/client/test/grammars/test-cases/strings.bb
@@ -122,3 +122,7 @@
 #           ^ source.bb string.quoted.double.bb
 #            ^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.double.bb
 #                               ^ source.bb string.quoted.double.bb
+
+>MYVAR = "This string contains literal \" and it should work"
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.double.bb
+#                                      ^^ source.bb string.quoted.double.bb constant.character.escape.bb 


### PR DESCRIPTION
A scope is explicitly assigned to the `\"` to avoid breaking the highlighting inside the string.  The rule for content within `[]` is also removed. As you can see the highlighting after `depends = []` is broken.
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/56c28111-91d6-441c-aca1-e20bc28cd7ab)

~~we will eventually have an embedded language service that handles the code within python/shell functions~~ temporary fixes like this will be applied for now. We are planning to use tree-sitter to provider extra support on syntax highlighting.
