### PR TITLE
Add completion items for operators and variable flags

### DIFF
--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -117,4 +117,107 @@ describe('On Completion', () => {
 
     expect(result).not.toEqual([])
   })
+
+  it('provides suggestions for overrides when a ":" is typed and it follows an identifier', async () => {
+    await analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.COMPLETION
+    })
+
+    const result = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 2,
+        character: 6
+      }
+    })
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          label: 'append',
+          kind: 24
+        }
+        // TODO: add an override item
+      ])
+    )
+  })
+
+  it('provides no suggestions when a ":" is typed but it doesn\'t follow an identifier', async () => {
+    await analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.COMPLETION
+    })
+
+    const result = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 13,
+        character: 1
+      }
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('provides fallback suggestions for variable flags when a "[" is typed and it follows an identifier', async () => {
+    // TODO: This one only tests the fallback suggestions, the ones from docs require scanning docs in bitbake folder
+    await analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.COMPLETION
+    })
+
+    const result = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 3,
+        character: 6
+      }
+    })
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          label: 'cleandirs',
+          kind: 14
+        }
+      ])
+    )
+  })
+
+  it('provides no suggestions when a "[" is typed but it doesn\'t follow a bitbake identifier', async () => {
+    await analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.COMPLETION
+    })
+
+    const result1 = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 12,
+        character: 1
+      }
+    })
+
+    const result2 = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 6,
+        character: 10
+      }
+    })
+
+    expect(result1).toEqual([])
+    expect(result2).toEqual([])
+  })
 })

--- a/server/src/__tests__/fixtures/completion.bb
+++ b/server/src/__tests__/fixtures/completion.bb
@@ -1,2 +1,14 @@
 FOO = '123'
 MYVAR = 'F${F}'
+MYVAR:append = '123'
+MYVAR[doc] 'this is docs'
+python (){
+    myvar = [1,2,3]
+    myvar[0] = 4
+}
+
+
+# Wrong code
+
+[]
+:

--- a/server/src/completions/bitbake-operator.ts
+++ b/server/src/completions/bitbake-operator.ts
@@ -1,0 +1,10 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export const BITBAKE_OPERATOR = [
+  'append',
+  'prepend',
+  'remove'
+]

--- a/server/src/completions/snippet-utils.ts
+++ b/server/src/completions/snippet-utils.ts
@@ -12,9 +12,9 @@ import { InsertTextFormat, type CompletionItem, CompletionItemKind, MarkupKind }
 
 /* eslint-disable no-template-curly-in-string */
 
-export function formatYoctoTaskSnippets (completions: CompletionItem[]): CompletionItem[] {
+export function formatCompletionItems (completions: CompletionItem[]): CompletionItem[] {
   return completions.map((item) => {
-    return {
+    const formatted = {
       ...item,
       insertTextFormat: InsertTextFormat.Snippet,
       documentation: {
@@ -26,13 +26,17 @@ export function formatYoctoTaskSnippets (completions: CompletionItem[]): Complet
           markdownBlock(item.insertText?.replace(/\$\{\d+:(?<code>.*)\}/g, (m, p1) => p1), 'bitbake'),
           '---',
           `${JSON.parse(JSON.stringify(item.documentation))}`,
-          `[Reference](https://docs.yoctoproject.org/singleindex.html#${item.label.replace(/_/g, '-')})`
+          item.data?.referenceUrl !== '' ? `[Reference](${item.data?.referenceUrl})` : ''
         ].join('\n'),
         kind: MarkupKind.Markdown
       },
 
       kind: CompletionItemKind.Snippet
     }
+
+    const { data, ...filtered } = formatted
+
+    return filtered
   })
 }
 

--- a/server/src/completions/variable-flags.ts
+++ b/server/src/completions/variable-flags.ts
@@ -1,0 +1,29 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export const VARIABLE_FLAGS = [
+  'cleandirs',
+  'depends',
+  'deptask',
+  'dirs',
+  'file-checksums',
+  'lockfiles',
+  'network',
+  'noexec',
+  'nostamp',
+  'number_threads',
+  'postfuncs',
+  'prefuncs',
+  'rdepends',
+  'rdeptask',
+  'recideptask',
+  'recrdeptask',
+  'stamp-extra-info',
+  'umask',
+  'vardeps',
+  'vardepsexclude',
+  'vardepvalue',
+  'vardepvalueexclude'
+]

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -9,7 +9,7 @@ import { symbolKindToCompletionKind } from '../utils/lsp'
 import { BITBAKE_VARIABLES } from '../completions/bitbake-variables'
 import { RESERVED_KEYWORDS } from '../completions/reserved-keywords'
 import { analyzer } from '../tree-sitter/analyzer'
-import { formatYoctoTaskSnippets } from '../completions/snippet-utils'
+import { formatCompletionItems } from '../completions/snippet-utils'
 import { bitBakeDocScanner } from '../BitBakeDocScanner'
 import { BITBAKE_OPERATOR } from '../completions/bitbake-operator'
 import { VARIABLE_FLAGS } from '../completions/variable-flags'
@@ -72,6 +72,8 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
       }
     })
     if (wordBeforeIsIdentifier) {
+      const variableFlagsFromScanner: CompletionItem[] = formatCompletionItems(bitBakeDocScanner.variablFlags)
+
       const variableFlagCompletionItems: CompletionItem[] = VARIABLE_FLAGS.map(keyword => {
         return {
           label: keyword,
@@ -79,7 +81,7 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
         }
       })
 
-      return variableFlagCompletionItems
+      return variableFlagsFromScanner.length > 0 ? variableFlagsFromScanner : variableFlagCompletionItems
     } else {
       return []
     }
@@ -112,7 +114,7 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
     }
   })
 
-  const yoctoTaskSnippets: CompletionItem[] = formatYoctoTaskSnippets(bitBakeDocScanner.yoctoTasks)
+  const yoctoTaskSnippets: CompletionItem[] = formatCompletionItems(bitBakeDocScanner.yoctoTasks)
 
   const allCompletions = [
     ...reserverdKeywordCompletionItems,

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -11,6 +11,8 @@ import { RESERVED_KEYWORDS } from '../completions/reserved-keywords'
 import { analyzer } from '../tree-sitter/analyzer'
 import { formatYoctoTaskSnippets } from '../completions/snippet-utils'
 import { bitBakeDocScanner } from '../BitBakeDocScanner'
+import { BITBAKE_OPERATOR } from '../completions/bitbake-operator'
+import { VARIABLE_FLAGS } from '../completions/variable-flags'
 
 export function onCompletionHandler (textDocumentPositionParams: TextDocumentPositionParams): CompletionItem[] {
   logger.debug('onCompletion')
@@ -32,6 +34,55 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
   // Do not provide completions if it is inside a string but not inside a variable expansion
   if (!shouldComplete) {
     return []
+  }
+
+  // bitbake operators
+  if (word === ':') {
+    const wordBeforeIsIdentifier = analyzer.isIdentifier({
+      ...textDocumentPositionParams,
+      position: {
+        line: textDocumentPositionParams.position.line,
+        // Go two character back as one character back is ':'
+        character: Math.max(textDocumentPositionParams.position.character - 2, 0)
+      }
+    })
+    if (wordBeforeIsIdentifier) {
+      const bitBakeOperatorCompletionItems: CompletionItem[] = BITBAKE_OPERATOR.map(keyword => {
+        return {
+          label: keyword,
+          kind: CompletionItemKind.Operator
+        }
+      })
+
+      return bitBakeOperatorCompletionItems
+    } else {
+      return []
+    }
+  }
+  // TODO: add dynamic overrides, completion type: Property
+
+  // variable flags
+  if (word === '[') {
+    const wordBeforeIsIdentifier = analyzer.isIdentifier({
+      ...textDocumentPositionParams,
+      position: {
+        line: textDocumentPositionParams.position.line,
+        // Go two character back as one character back is ':'
+        character: Math.max(textDocumentPositionParams.position.character - 2, 0)
+      }
+    })
+    if (wordBeforeIsIdentifier) {
+      const variableFlagCompletionItems: CompletionItem[] = VARIABLE_FLAGS.map(keyword => {
+        return {
+          label: keyword,
+          kind: CompletionItemKind.Keyword
+        }
+      })
+
+      return variableFlagCompletionItems
+    } else {
+      return []
+    }
   }
 
   let symbolCompletions: CompletionItem[] = []

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -46,7 +46,8 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       completionProvider: {
-        resolveProvider: true
+        resolveProvider: true,
+        triggerCharacters: [':', '[']
       },
       definitionProvider: true,
       executeCommandProvider: {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -85,7 +85,7 @@ connection.onDidChangeConfiguration((change) => {
   bitBakeProjectScanner.pathToBuildFolder = settings.bitbake.pathToBuildFolder
   bitBakeProjectScanner.pathToBitbakeFolder = settings.bitbake.pathToBitbakeFolder
   bitBakeDocScanner.parse(settings.bitbake.pathToBitbakeFolder)
-
+  bitBakeDocScanner.parseVariableFlag(settings.bitbake.pathToBitbakeFolder)
   bitBakeProjectScanner.rescanProject()
 })
 

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -127,6 +127,17 @@ export default class Analyzer {
     this.uriToAnalyzedDocument = {}
   }
 
+  public isIdentifier (
+    params: TextDocumentPositionParams
+  ): boolean {
+    const n = this.nodeAtPoint(
+      params.textDocument.uri,
+      params.position.line,
+      params.position.character
+    )
+    return n?.type === 'identifier'
+  }
+
   /**
    * Find the node at the given point.
    */


### PR DESCRIPTION
Override syntax completion will be triggered by typing `:` and variable flag completion will be triggered by typing `[` as long as they follow an `identifier` which is a type defined by the tree-sitter-bitbake. 

Only a list of minimum items is added as I didn't find the complete docs for them. The mechanics of adding completion items are ready for review.

sample result:
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/06741304-2f31-4347-8d62-a596d34a42f0)
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/51d52da1-d60b-4570-ab4d-763ee16982da)
