### PR TITLE
Refactor: Remove connection from class members etc

### DIFF
--- a/server/src/BitBakeProjectScanner.ts
+++ b/server/src/BitBakeProjectScanner.ts
@@ -11,19 +11,15 @@ import fs from 'fs'
 import logger from 'winston'
 
 import type {
-  Connection
-} from 'vscode-languageserver'
-import type {
   ElementInfo,
   LayerInfo,
   PathInfo
 } from './ElementInfo'
 
-import {
-  OutputParser
-} from './OutputParser'
-import { ServerNotificationManager } from './ServerNotificationManager'
-
+import
+outputParser
+  from './OutputParser'
+import { serverNotificationManager } from './ServerNotificationManager'
 interface ScannStatus {
   scanIsRunning: boolean
   scanIsPending: boolean
@@ -42,17 +38,10 @@ export class BitBakeProjectScanner {
   private _classes: ElementInfo[] = new Array < ElementInfo >()
   private _includes: ElementInfo[] = new Array < ElementInfo >()
   private _recipes: ElementInfo[] = new Array < ElementInfo >()
-  private readonly _outputParser: OutputParser
-  private readonly _notificationManager: ServerNotificationManager
   private _shouldDeepExamine: boolean = false
   private _pathToBuildFolder: string = 'build'
   private _pathToEnvScript: string = 'oe-init-build-env'
   private _pathToBitbakeFolder: string = 'bitbake'
-
-  constructor (connection: Connection) {
-    this._outputParser = new OutputParser(connection)
-    this._notificationManager = new ServerNotificationManager(connection)
-  }
 
   private readonly _scanStatus: ScannStatus = {
     scanIsRunning: false,
@@ -190,7 +179,7 @@ export class BitBakeProjectScanner {
     } else {
       const error = commandResult.stderr.toString()
       logger.error(`can not scan available layers error: ${error}`)
-      this._outputParser.parse(error)
+      outputParser.parse(error)
     }
   }
 
@@ -268,9 +257,9 @@ export class BitBakeProjectScanner {
 
     const commandResult = this.executeBitBakeCommand('bitbake -p')
     const output = commandResult.output.toString()
-    this._outputParser.parse(output)
-    if (this._outputParser.errorsFound()) {
-      this._outputParser.reportProblems()
+    outputParser.parse(output)
+    if (outputParser.errorsFound()) {
+      outputParser.reportProblems()
       parsingSuccess = false
     } else {
       if (commandResult.status !== 0) {
@@ -354,7 +343,7 @@ export class BitBakeProjectScanner {
       if (output.includes('bitbake')) {
         // Seems like Bitbake could not be found.
         // Are we sure this is the actual error?
-        this._notificationManager.sendBitBakeNotFound()
+        serverNotificationManager.sendBitBakeNotFound()
         throw new Error(output)
       }
     }
@@ -386,3 +375,6 @@ export class BitBakeProjectScanner {
     return scriptFileBuffer.join('\n')
   }
 }
+
+const bitBakeProjectScanner = new BitBakeProjectScanner()
+export default bitBakeProjectScanner

--- a/server/src/ContextHandler.ts
+++ b/server/src/ContextHandler.ts
@@ -29,6 +29,7 @@ import type {
 } from './SymbolScanner'
 
 import logger from 'winston'
+import bitBakeProjectScanner from './BitBakeProjectScanner'
 
 /**
  * ContextHandler
@@ -170,3 +171,6 @@ export class ContextHandler {
     return keyword
   }
 }
+
+const contextHandler = new ContextHandler(bitBakeProjectScanner)
+export default contextHandler

--- a/server/src/OutputParser.ts
+++ b/server/src/OutputParser.ts
@@ -14,13 +14,17 @@ import {
   ProblemsContainer
 } from './ProblemsContainer'
 
+let _connection: Connection | null = null
+
+/**
+ * Set the connection. Should be done at startup.
+ */
+export function setOutputParserConnection (connection: Connection): void {
+  _connection = connection
+}
+
 export class OutputParser {
   _problems: ProblemsContainer[] = []
-  _connection: Connection
-
-  constructor (connection: Connection) {
-    this._connection = connection
-  }
 
   parse (message: string): void {
     this.clearAllProblemsAndReport()
@@ -59,20 +63,33 @@ export class OutputParser {
   }
 
   reportProblems (): void {
+    if (_connection === null) {
+      logger.warn('The LSP Connection is not set. Dropping messages')
+      return
+    }
+    const connection = _connection
     logger.debug(`reportProblems: ${this._problems.length}`)
     this._problems.forEach((container: ProblemsContainer) => {
       logger.debug(`send Diagnostic ${container.toString()}`)
-      void this._connection.sendDiagnostics(container.getDignosticData())
+      void connection.sendDiagnostics(container.getDignosticData())
     })
   }
 
   clearAllProblemsAndReport (): void {
+    if (_connection === null) {
+      logger.warn('The LSP Connection is not set. Dropping messages')
+      return
+    }
+    const connection = _connection
     logger.debug(`clearAllProblems: ${this._problems.length}`)
     this._problems.forEach((container: ProblemsContainer) => {
       logger.debug(`send Diagnostic ${container.toString()}`)
-      void this._connection.sendDiagnostics(container.getClearedDiagnosticData())
+      void connection.sendDiagnostics(container.getClearedDiagnosticData())
     })
 
     this._problems = []
   }
 }
+
+const outputParser = new OutputParser()
+export default outputParser

--- a/server/src/ServerNotificationManager.ts
+++ b/server/src/ServerNotificationManager.ts
@@ -5,21 +5,31 @@
 
 import { type Connection } from 'vscode-languageserver'
 
+let _connection: Connection | null = null
+
+/**
+ * Set the connection. Should be done at startup.
+ */
+export function setNotificationManagerConnection (connection: Connection): void {
+  _connection = connection
+}
+
 export type NotificationType =
   'custom/bitBakeNotFound'
 
-export class ServerNotificationManager {
-  private readonly _connection: Connection
-
-  constructor (connection: Connection) {
-    this._connection = connection
-  }
-
+class ServerNotificationManager {
   send (type: NotificationType, message?: string): void {
-    void this._connection.sendNotification(type, message)
+    if (_connection === null) {
+      // eslint-disable-next-line no-console
+      console.warn('The LSP Connection is not set. Dropping messages')
+      return
+    }
+    void _connection.sendNotification(type, message)
   }
 
   sendBitBakeNotFound (): void {
     this.send('custom/bitBakeNotFound')
   }
 }
+
+export const serverNotificationManager = new ServerNotificationManager()

--- a/server/src/connectionHandlers/onDefinition.ts
+++ b/server/src/connectionHandlers/onDefinition.ts
@@ -1,0 +1,20 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import logger from 'winston'
+import { type TextDocumentPositionParams, type Definition } from 'vscode-languageserver/node'
+import { analyzer } from '../tree-sitter/analyzer'
+import contextHandler from '../ContextHandler'
+
+export function onDefinitionHandler (textDocumentPositionParams: TextDocumentPositionParams): Definition {
+  logger.debug(`onDefinition ${JSON.stringify(textDocumentPositionParams)}`)
+  const documentAsText = analyzer.getDocumentTexts(textDocumentPositionParams.textDocument.uri)
+
+  if (documentAsText === undefined) {
+    return []
+  }
+
+  return contextHandler.getDefinition(textDocumentPositionParams, documentAsText)
+}

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -31,6 +31,10 @@ export default class Analyzer {
   private uriToAnalyzedDocument: Record<string, AnalyzedDocument | undefined> = {}
   private debouncedExecuteAnalyzation?: ReturnType<typeof debounce>
 
+  public getDocumentTexts (uri: string): string[] | undefined {
+    return this.uriToAnalyzedDocument[uri]?.document.getText().split(/\r?\n/g)
+  }
+
   public initialize (parser: Parser): void {
     this.parser = parser
   }
@@ -42,12 +46,13 @@ export default class Analyzer {
     document: TextDocument
     uri: string
   }): Promise<Diagnostic[]> {
-    const fileContent = document.getText()
-
     if (this.parser === undefined) {
       console.log('The analyzer is not initialized with a parser')
       return await Promise.resolve([])
     }
+
+    const fileContent = document.getText()
+
     const tree = this.parser.parse(fileContent)
     const globalDeclarations = getGlobalDeclarations({ tree, uri })
 


### PR DESCRIPTION
1.`OutputParser` and `serverNotificationManager` don't need to instantiate with `connection`. The connection can be set on start up. Plus, some classes only need one instance, I export one from the file where the class is defined to make sure everywhere else can reference the same instance.
~~2.`documentAsTextMap` and Analyzer's `uriToAnalyzedDocument` have some similarities. They can be merged later. For now, they can both be members of the Analyzer~~
2. Analyzer's `uriToAnalyzedDocument` already has a TextDocument object, so I use it to replace the `documentAsTextMap`
3. `onDefinitionHandler` is put in its own file for better testing