### PR TITLE
Refactor: Rename ClientNotificationManager to PopupManager

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import { type LanguageClient } from 'vscode-languageclient/node'
 
-import { ClientNotificationManager } from './ui/ClientNotificationManager'
+import { PopupManager } from './ui/PopupManager'
 import { logger } from './lib/src/utils/OutputLogger'
 import { activateLanguageServer, deactivateLanguageServer } from './language/languageClient'
 import { BitbakeDriver } from './lib/src/BitbakeDriver'
@@ -37,7 +37,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 
   taskProvider = vscode.tasks.registerTaskProvider('bitbake', bitbakeTaskProvider)
 
-  const notificationManager = new ClientNotificationManager(client, context.globalState)
+  const notificationManager = new PopupManager(client, context.globalState)
   context.subscriptions.push(...notificationManager.buildHandlers())
 
   // Handle settings change for bitbake driver

--- a/client/src/ui/PopupManager.ts
+++ b/client/src/ui/PopupManager.ts
@@ -6,7 +6,7 @@
 import { type Memento, commands, window } from 'vscode'
 import { type LanguageClient, type Disposable } from 'vscode-languageclient/node'
 
-export class ClientNotificationManager {
+export class PopupManager {
   private readonly _client: LanguageClient
   private readonly _memento: Memento
 

--- a/server/src/NotificationManager.ts
+++ b/server/src/NotificationManager.ts
@@ -17,7 +17,7 @@ export function setNotificationManagerConnection (connection: Connection): void 
 export type NotificationType =
   'custom/bitBakeNotFound'
 
-class ServerNotificationManager {
+class NotificationManager {
   send (type: NotificationType, message?: string): void {
     if (_connection === null) {
       // eslint-disable-next-line no-console
@@ -32,4 +32,4 @@ class ServerNotificationManager {
   }
 }
 
-export const serverNotificationManager = new ServerNotificationManager()
+export const notificationManager = new NotificationManager()

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,7 +25,7 @@ import { logger } from './lib/src/utils/OutputLogger'
 import { onCompletionHandler } from './connectionHandlers/onCompletion'
 import { onDefinitionHandler } from './connectionHandlers/onDefinition'
 import { setOutputParserConnection } from './OutputParser'
-import { setNotificationManagerConnection, serverNotificationManager } from './ServerNotificationManager'
+import { setNotificationManagerConnection, notificationManager } from './NotificationManager'
 import { onHoverHandler } from './connectionHandlers/onHover'
 
 // Create a connection for the server. The connection uses Node's IPC as a transport
@@ -72,7 +72,7 @@ function checkBitbakePresence (): void {
   const bitbakeBinPath = bitbakeFolder + '/bin/bitbake'
 
   if (!fs.existsSync(bitbakeBinPath)) {
-    serverNotificationManager.sendBitBakeNotFound()
+    notificationManager.sendBitBakeNotFound()
   }
 }
 


### PR DESCRIPTION
While trying to make some order into the requests and notifications, I noticed the ClientNotificationManager is not about "notifications" in VS Code terminology, but rather messages. I currently need to create a true NotificationManager (for useful purpose) but this name is not available.