### PR TITLE
Set logger level in onInitialize event

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -38,8 +38,9 @@ const documents = new TextDocuments<TextDocument>(TextDocument)
 let workspaceRoot: string = ''
 
 connection.onInitialize(async (params: InitializeParams): Promise<InitializeResult> => {
+  logger.level = 'debug'
+  logger.info('[onInitialize] Initializing connection')
   workspaceRoot = new URL(params.workspaceFolders?.[0]?.uri ?? '').pathname
-
   setOutputParserConnection(connection)
   setNotificationManagerConnection(connection)
 


### PR DESCRIPTION
The default logger level is none, so all logs in onInitialize (which fires before `onDidChangeConfiguration`) won't show. Thus, set a temporary logger level to enable the logs in this event. It will then be overridden by extension settings later in `onDidChangeConfiguration`