### PR TITLE
Various updates and fixes on completion

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -8,8 +8,7 @@ import * as path from 'path'
 import {
   workspace,
   type ExtensionContext,
-  window,
-  ConfigurationTarget
+  window
 } from 'vscode'
 
 import {
@@ -87,16 +86,6 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
           void window.showErrorMessage(`Failed to associate this file (${param.filePath}) with BitBake Language mode. Current language mode: ${languageId}. Please make sure there is no other extension that is causing the conflict. (e.g. Txt Syntax)`)
         }
       }, 1000)
-    }
-  })
-
-  // Enable suggestions when inside strings, but server side disables suggestions on pure string content, they are onlyavailable in the variable expansion
-  window.onDidChangeActiveTextEditor((editor) => {
-    if (editor !== null && editor?.document.languageId === 'bitbake') {
-      void workspace.getConfiguration('editor').update('quickSuggestions', { strings: true }, ConfigurationTarget.Workspace)
-    } else {
-      // Reset to default settings
-      void workspace.getConfiguration('editor').update('quickSuggestions', { strings: false }, ConfigurationTarget.Workspace)
     }
   })
 

--- a/client/syntaxes/bitbake.tmLanguage.json
+++ b/client/syntaxes/bitbake.tmLanguage.json
@@ -41,7 +41,7 @@
         "keywords": {
             "patterns": [
                 {
-                    "match": "\\b(include|require|inherit|addtask|deltask|after|before|export|echo|if|fi|unset|print|fakeroot|EXPORT_FUNCTIONS|INHERIT)\\b",
+                    "match": "(?<![[:punct:]])\\b(include|require|inherit|addtask|deltask|after|before|export|echo|if|fi|unset|print|fakeroot|EXPORT_FUNCTIONS|INHERIT)\\b(?![[:punct:]])",
                     "captures": {
                         "1": {
                             "name": "keyword.control.bb"
@@ -52,7 +52,7 @@
                     "include": "#python-keywords"
                 },
                 {
-                    "match": "\\s*(python)(?=\\s+|\\s*\\()",
+                    "match": "\\b(python|def)\\b(?![[:punct:]])",
                     "captures": {
                         "1": {
                             "name": "storage.type.function.python.bb"

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -100,7 +100,7 @@ describe('On Completion', () => {
     expect(result).toEqual([])
   })
 
-  it('provides suggestions when it is in variable expansion', async () => {
+  it('provides necessary suggestions when it is in variable expansion', async () => {
     await analyzer.analyze({
       uri: DUMMY_URI,
       document: FIXTURE_DOCUMENT.COMPLETION
@@ -117,6 +117,14 @@ describe('On Completion', () => {
     })
 
     expect(result).not.toEqual([])
+    expect(result).not.toEqual(
+      expect.arrayContaining([
+        {
+          kind: 14,
+          label: 'python'
+        }
+      ])
+    )
   })
 
   it('provides suggestions for operators when a ":" is typed and it follows an identifier or in the middle of typing such syntax', async () => {

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -119,7 +119,7 @@ describe('On Completion', () => {
     expect(result).not.toEqual([])
   })
 
-  it('provides suggestions for operators when a ":" is typed and it follows an identifier', async () => {
+  it('provides suggestions for operators when a ":" is typed and it follows an identifier or in the middle of typing such syntax', async () => {
     await analyzer.analyze({
       uri: DUMMY_URI,
       document: FIXTURE_DOCUMENT.COMPLETION
@@ -135,7 +135,27 @@ describe('On Completion', () => {
       }
     })
 
+    // In the middle of typing operator/override syntax
+    const result2 = onCompletionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 2,
+        character: 7
+      }
+    })
+
     expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          label: 'append',
+          kind: 24
+        }
+      ])
+    )
+
+    expect(result2).toEqual(
       expect.arrayContaining([
         {
           label: 'append',

--- a/server/src/completions/snippet-utils.ts
+++ b/server/src/completions/snippet-utils.ts
@@ -12,7 +12,7 @@ import { InsertTextFormat, type CompletionItem, CompletionItemKind, MarkupKind }
 
 /* eslint-disable no-template-curly-in-string */
 
-export function formatCompletionItems (completions: CompletionItem[]): CompletionItem[] {
+export function formatCompletionItems (completions: CompletionItem[], completionItemKind?: CompletionItemKind): CompletionItem[] {
   return completions.map((item) => {
     const formatted = {
       ...item,
@@ -31,7 +31,7 @@ export function formatCompletionItems (completions: CompletionItem[]): Completio
         kind: MarkupKind.Markdown
       },
 
-      kind: CompletionItemKind.Snippet
+      kind: item.kind ?? completionItemKind ?? CompletionItemKind.Snippet
     }
 
     const { data, ...filtered } = formatted

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -123,12 +123,15 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
 
   // TODO: Add completions from contextHandler.getCompletionItemForRecipesAndSymbols() after refactor the CompletionProviders & SymbolScanner & ProjectScanner
 
-  const reserverdKeywordCompletionItems: CompletionItem[] = RESERVED_KEYWORDS.map(keyword => {
-    return {
-      label: keyword,
-      kind: CompletionItemKind.Keyword
-    }
-  })
+  let reserverdKeywordCompletionItems: CompletionItem[] = []
+  if (!analyzer.isVariableExpansion(documentUri, wordPosition.line, wordPosition.character)) {
+    reserverdKeywordCompletionItems = RESERVED_KEYWORDS.map(keyword => {
+      return {
+        label: keyword,
+        kind: CompletionItemKind.Keyword
+      }
+    })
+  }
 
   const bitBakeVariableCompletionItems: CompletionItem[] = bitBakeDocScanner.variableCompletionItems.length > 0
     ? formatCompletionItems(bitBakeDocScanner.variableCompletionItems)

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -86,7 +86,7 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
       }
     })
     if (wordBeforeIsIdentifier) {
-      const variableFlagsFromScanner: CompletionItem[] = formatCompletionItems(bitBakeDocScanner.variableFlagCompletionItems)
+      const variableFlagsFromScanner: CompletionItem[] = formatCompletionItems(bitBakeDocScanner.variableFlagCompletionItems, CompletionItemKind.Keyword)
 
       const variableFlagCompletionItems: CompletionItem[] = VARIABLE_FLAGS.map(keyword => {
         return {
@@ -134,7 +134,7 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
   }
 
   const bitBakeVariableCompletionItems: CompletionItem[] = bitBakeDocScanner.variableCompletionItems.length > 0
-    ? formatCompletionItems(bitBakeDocScanner.variableCompletionItems)
+    ? formatCompletionItems(bitBakeDocScanner.variableCompletionItems, CompletionItemKind.Variable)
     : BITBAKE_VARIABLES.map(keyword => {
       return {
         label: keyword,
@@ -142,7 +142,7 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
       }
     })
 
-  const yoctoTaskSnippets: CompletionItem[] = formatCompletionItems(bitBakeDocScanner.yoctoTaskCompletionItems)
+  const yoctoTaskSnippets: CompletionItem[] = formatCompletionItems(bitBakeDocScanner.yoctoTaskCompletionItems, CompletionItemKind.Snippet)
 
   const allCompletions = [
     ...reserverdKeywordCompletionItems,

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -135,18 +135,6 @@ export default class Analyzer {
     )
   }
 
-  public shouldProvideCompletionItems (
-    uri: string,
-    line: number,
-    column: number
-  ): boolean {
-    const n = this.nodeAtPoint(uri, line, column)
-    if (n?.type === 'string_content' || n?.type === 'ERROR') {
-      return false
-    }
-    return true
-  }
-
   public hasParser (): boolean {
     return this.parser !== undefined
   }
@@ -197,6 +185,33 @@ export default class Analyzer {
       params.position.character
     )
     return n?.type === 'identifier'
+  }
+
+  public isStringContent (
+    uri: string,
+    line: number,
+    column: number
+  ): boolean {
+    const n = this.nodeAtPoint(uri, line, column)
+    if (n?.type === 'string_content') {
+      return true
+    }
+    return false
+  }
+
+  public isOverride (
+    uri: string,
+    line: number,
+    column: number
+  ): boolean {
+    const n = this.nodeAtPoint(uri, line, column)
+    // Current tree-sitter @1.0.1 only treats 'append', 'prepend' and 'remove' as a node with "override" type. Other words following ":" will yield a node with "identifier" type whose parent node is of type "override"
+    // However, in some cases, its parent node is not of type override but its grandparent is.
+    // See if future tree-sitter has a nicer way to handle this.
+    if (n?.type === 'override' || n?.parent?.type === 'override' || n?.parent?.parent?.type === 'override') {
+      return true
+    }
+    return false
   }
 
   /**

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -215,6 +215,24 @@ export default class Analyzer {
   }
 
   /**
+   * Check if the variable expansion syntax is being typed. Only for expressions that reference variables. \
+   * Example:
+   * ```
+   * NAME = "foo"
+   * DESCRIPTION = "Name: ${NAME}"
+   * ```
+   * Caveat: Current tree-sitter @1.0.1 doesn't treat "${}" as variable expansion syntax.
+   */
+  public isVariableExpansion (
+    uri: string,
+    line: number,
+    column: number
+  ): boolean {
+    const n = this.nodeAtPoint(uri, line, column)
+    return n?.type === 'identifier' && n?.parent?.type === 'variable_expansion'
+  }
+
+  /**
    * Check if the node is the identifier in a variable assignment syntax (identifiers are only on the left hand side)
    */
   public isIdentifierOfVariableAssignment (


### PR DESCRIPTION
1. Add a rule to not highlight keywords if they follow or are followed by any special character. (`\b` only handles letters, digits and underscore)
Not all keywords are covered consider the possibility of inline code (Is that a case?)
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/e97a1666-0bb8-4574-acad-3318fe73ecda)

2. Enable the completion in the middle of typing override/operator syntax
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/dade835c-38dc-484e-ab0f-2663ebe895d9)

3. Remove the code that sets the editor quick suggestion for strings to true. Because this also disabled word-based suggestion (Simple words that are ever typed in the document). The context-based suggestion is disabled using the tree-sitter.
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/cfce84a7-e434-400f-a125-07bcd79f1f62)

4. Add variable expansion check to limit completion items in it. Currently, the keywords won't show anymore. Note that the current tree-sitter won't treat `"${}"` as variable expansion. @deribaucourt And I think it is a rare case that people trigger suggestions in an empty `${}`. I will prefer to leave it for now until tree-sitter can handle it.
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/02a345eb-76b6-44ea-a68d-73d42157ffe5)
