### PR TITLE
Fix: Replace pn-defaultpkgname with ${PN}

### DIFF
--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -60,11 +60,16 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
       })
 
       const bitbakeOverridesCompletionItems: CompletionItem[] = bitBakeProjectScanner.overrides.map((override, index) => {
+        let label = override
+        if (override === 'pn-defaultpkgname') {
+          // eslint-disable-next-line no-template-curly-in-string
+          label = '${PN}'
+        }
         return {
-          label: override,
+          label,
           kind: CompletionItemKind.Property,
           // Present overrides after operators, in order of priority
-          sortText: '~' + String.fromCharCode(21 + index) + override
+          sortText: '~' + String.fromCharCode(21 + index) + label
         }
       })
 


### PR DESCRIPTION
The overrides are scanned using no specific recipe. The corresponding package override, pn-defaultpkgname does not exist in this case. Commonly, ${PN} is used instead.