### PR TITLE
Refactor, add variables from yocto docs, add hover definition for yocto docs, etc

### DIFF
--- a/scripts/fetch-docs.sh
+++ b/scripts/fetch-docs.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+BITBAKE_DOCS_COMMIT=595176d6be95a9c4718d3a40499d1eb576b535f5
+BITBAKE_DOCS_LIST="bitbake-user-manual-metadata.rst bitbake-user-manual-ref-variables.rst"
+
+YOCTO_DOCS_COMMIT=897d5017eae6b3af2d5d489fc4e0915d9ce21458
+YOCTO_DOCS_LIST=" tasks.rst variables.rst"
+
 set -e
 
 mkdir -p resources/docs 
@@ -7,9 +14,9 @@ git clone --depth 1 --filter=blob:none --sparse https://github.com/openembedded/
 cd bitbake 
 git sparse-checkout set doc/bitbake-user-manual/ 
 git fetch origin
-git checkout 595176d6be95a9c4718d3a40499d1eb576b535f5
+git checkout $BITBAKE_DOCS_COMMIT
 cd doc/bitbake-user-manual/ 
-mv bitbake-user-manual-metadata.rst bitbake-user-manual-ref-variables.rst  ../../../resources/docs 
+mv $BITBAKE_DOCS_LIST  ../../../resources/docs 
 cd ../../../ 
 rm -rf bitbake
 
@@ -18,9 +25,9 @@ git clone --depth 1 --filter=blob:none --sparse https://git.yoctoproject.org/yoc
 cd yocto-docs 
 git sparse-checkout set documentation/ref-manual 
 git fetch origin
-git checkout 897d5017eae6b3af2d5d489fc4e0915d9ce21458
+git checkout $YOCTO_DOCS_COMMIT
 cd documentation/ref-manual 
-mv tasks.rst ../../../resources/docs 
+mv $YOCTO_DOCS_LIST ../../../resources/docs 
 cd ../../../ 
 rm -rf yocto-docs
 

--- a/server/src/BitBakeDocScanner.ts
+++ b/server/src/BitBakeDocScanner.ts
@@ -71,6 +71,13 @@ export class BitBakeDocScanner {
     return this._yoctoTaskInfo
   }
 
+  public clearScannedDocs (): void {
+    this._bitbakeVariableInfo = []
+    this._yoctoVariableInfo = []
+    this._variableFlagInfo = []
+    this._yoctoTaskInfo = []
+  }
+
   public setDocPathAndParse (extensionPath: string): void {
     this._docPath = path.join(extensionPath, '../resources/docs')
     this.parseVariableFlagFile()

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -96,17 +96,16 @@ describe('On Completion', () => {
         }
       ])
     )
-    // Variables from scanning bitbake docs
+    // Variables from yocto docs after filtering the duplicates
     expect(resultAfterDocScan).toEqual(
-      /* eslint-disable no-template-curly-in-string */
       expect.arrayContaining([
         {
           documentation: {
-            value: '```man\nDESCRIPTION (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   A long description for the recipe.\n\n\n[Reference](https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-ref-variables.html#term-DESCRIPTION)',
+            value: '```man\nDESCRIPTION (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   The package description used by package managers. If not set,\n   `DESCRIPTION` takes the value of the `SUMMARY`\n   variable.\n\n\n[Reference](https://docs.yoctoproject.org/ref-manual/variables.html#term-DESCRIPTION)',
             kind: 'markdown'
           },
           labelDetails: {
-            description: 'Source: Bitbake'
+            description: 'Source: Yocto'
           },
           insertText: undefined,
           insertTextFormat: 1,
@@ -115,7 +114,27 @@ describe('On Completion', () => {
         }
       ])
     )
-    // Variables from scanning Yocto docs
+    // Variables from bitbake docs after filtering the duplicates
+    expect(resultAfterDocScan).toEqual(
+      expect.arrayContaining([
+        {
+          documentation: {
+            /* eslint-disable no-useless-escape */
+            value: '```man\nBB_HASH_CODEPARSER_VALS (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   Specifies values for variables to use when populating the codeparser cache.\n   This can be used selectively to set dummy values for variables to avoid\n   the codeparser cache growing on every parse. Variables that would typically\n   be included are those where the value is not significant for where the\n   codeparser cache is used (i.e. when calculating variable dependencies for\n   code fragments.) The value is space-separated without quoting values, for\n   example:\n BB_HASH_CODEPARSER_VALS = \"T=/ WORKDIR=/ DATE=1234 TIME=1234\"\n\n\n[Reference](https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-ref-variables.html#term-BB_HASH_CODEPARSER_VALS)',
+            kind: 'markdown'
+          },
+          labelDetails: {
+            description: 'Source: Bitbake'
+          },
+          insertText: undefined,
+          insertTextFormat: 1,
+          label: 'BB_HASH_CODEPARSER_VALS',
+          kind: 6
+        }
+      ])
+    )
+
+    // Variables from Yocto docs but not in bitbake docs
     expect(resultAfterDocScan).toEqual(
       /* eslint-disable no-template-curly-in-string */
       expect.arrayContaining([

--- a/server/src/__tests__/fixtures/hover.bb
+++ b/server/src/__tests__/fixtures/hover.bb
@@ -9,3 +9,21 @@ python DESCRIPTION(){
 MYVAR = 'Nothing should show on hovering this DESCRIPTION'
 
 MYDESCRIPTION = 'Definition for DESCRIPTION should not show on MYDESCRIPTION'
+
+MYVAR[cleandirs] = 'Definition for flag cleandirs should show'
+MYVAR[mycleandirs] = 'Definition for flag cleandirs should not show'
+
+do_build(){
+
+}
+
+python do_build(){
+
+}
+
+def do_build():
+    pass
+
+my_do_build(){
+    VAR = 'do_build'
+}

--- a/server/src/completions/snippet-utils.ts
+++ b/server/src/completions/snippet-utils.ts
@@ -16,7 +16,7 @@ export function formatCompletionItems (completions: CompletionItem[], completion
   return completions.map((item) => {
     const formatted = {
       ...item,
-      insertTextFormat: InsertTextFormat.Snippet,
+      insertTextFormat: item.insertText !== undefined ? InsertTextFormat.Snippet : InsertTextFormat.PlainText,
       documentation: {
         value: [
           markdownBlock(

--- a/server/src/completions/snippet-utils.ts
+++ b/server/src/completions/snippet-utils.ts
@@ -26,7 +26,7 @@ export function formatCompletionItems (completions: CompletionItem[], completion
           markdownBlock(item.insertText?.replace(/\$\{\d+:(?<code>.*)\}/g, (m, p1) => p1), 'bitbake'),
           '---',
           `${JSON.parse(JSON.stringify(item.documentation))}`,
-          item.data?.referenceUrl !== '' ? `[Reference](${item.data?.referenceUrl})` : ''
+          item.data.referenceUrl !== undefined ? `[Reference](${item.data?.referenceUrl})` : ''
         ].join('\n'),
         kind: MarkupKind.Markdown
       },

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -151,11 +151,16 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
 
   const yoctoVariableCompletionItems: CompletionItem[] = formatCompletionItems(docInfoToCompletionItems(bitBakeDocScanner.yoctoVariableInfo), CompletionItemKind.Variable)
 
+  // Remove the duplicate variables by their names. It still keeps the fallback variables from BITBAKE_VARIABLES before scanning the docs since yoctoVariableCompletionItems will be [] in that case
+  const variableCompletionItems: CompletionItem[] = [
+    ...bitBakeVariableCompletionItems.filter((bitbakeVariable) => !yoctoVariableCompletionItems.some(yoctoVariable => yoctoVariable.label === bitbakeVariable.label)),
+    ...yoctoVariableCompletionItems
+  ]
+
   const allCompletions = [
     ...reserverdKeywordCompletionItems,
-    ...bitBakeVariableCompletionItems,
+    ...variableCompletionItems,
     ...yoctoTaskSnippets,
-    ...yoctoVariableCompletionItems,
     ...symbolCompletions
   ]
 

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -149,10 +149,13 @@ export function onCompletionHandler (textDocumentPositionParams: TextDocumentPos
 
   const yoctoTaskSnippets: CompletionItem[] = formatCompletionItems(docInfoToCompletionItems(bitBakeDocScanner.yoctoTaskInfo), CompletionItemKind.Snippet)
 
+  const yoctoVariableCompletionItems: CompletionItem[] = formatCompletionItems(docInfoToCompletionItems(bitBakeDocScanner.yoctoVariableInfo), CompletionItemKind.Variable)
+
   const allCompletions = [
     ...reserverdKeywordCompletionItems,
     ...bitBakeVariableCompletionItems,
     ...yoctoTaskSnippets,
+    ...yoctoVariableCompletionItems,
     ...symbolCompletions
   ]
 

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -37,11 +37,10 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
       return null
     }
 
-    const definition = found.definition
     const hover: Hover = {
       contents: {
         kind: 'markdown',
-        value: `**${word}**\n___\n${definition}`
+        value: `**${found.name}**\n___\n${found.definition}`
       }
     }
     logger.debug(`[onHover] Hover item: ${JSON.stringify(hover)}`)
@@ -58,12 +57,28 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
     const hover: Hover = {
       contents: {
         kind: 'markdown',
-        value: `**${word}**\n___\n${found.definition}`
+        value: `**${found.name}**\n___\n${found.definition}`
       }
     }
     logger.debug(`[onHover] Hover item: ${JSON.stringify(hover)}`)
     return hover
   }
 
+  // Yocto tasks
+  if (analyzer.isFunctionIdentifier(params)) {
+    const found = bitBakeDocScanner.yoctoTaskInfo.find(item => item.name === word)
+    if (found === undefined) {
+      return null
+    }
+    logger.debug(`[onHover] Found Yocto task: ${found.name}`)
+    const hover: Hover = {
+      contents: {
+        kind: 'markdown',
+        value: `**${found.name}**\n___\n${found.definition}`
+      }
+    }
+    logger.debug(`[onHover] Hover item: ${JSON.stringify(hover)}`)
+    return hover
+  }
   return null
 }

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -186,6 +186,22 @@ export default class Analyzer {
     return n?.type === 'identifier'
   }
 
+  public isFunctionIdentifier (
+    params: TextDocumentPositionParams
+  ): boolean {
+    const n = this.nodeAtPoint(
+      params.textDocument.uri,
+      params.position.line,
+      params.position.character
+    )
+    if (n?.type === 'identifier') {
+      return n?.parent?.type === 'function_definition' || n?.parent?.type === 'anonymous_python_function'
+    } else if (n?.type === 'python_identifier') {
+      return n?.parent?.type === 'python_function_definition'
+    }
+    return false
+  }
+
   public isStringContent (
     uri: string,
     line: number,


### PR DESCRIPTION
1. Refactored the bitbakeDocScanner. It won't store completion items. The conversion happens in `onCompletion` handler.
2. Added variables from yocto docs.
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/66683318-9799-4a97-9027-535afcdfcec4)

3. Added hover definition for yocto tasks.
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/a41f8c4a-7ad0-4f76-bea2-803d2dce7f9a)

4. Updated the tests.