### PR TITLE
Feature 10418 add hover definition for variable references

### DIFF
--- a/server/src/__tests__/fixtures/hover.bb
+++ b/server/src/__tests__/fixtures/hover.bb
@@ -1,7 +1,7 @@
-# Should show definiton on hover
-DESCRIPTION = 'This is a description'
 
-# Should not show definition on hover
+DESCRIPTION = 'This is a description'
+MYVAR = "${DESCRIPTION}"
+MYVAR:${DESCRIPTION} = 'foo'
 python DESCRIPTION(){
     print('123')
 }

--- a/server/src/__tests__/hover.test.ts
+++ b/server/src/__tests__/hover.test.ts
@@ -25,20 +25,40 @@ describe('on hover', () => {
     bitBakeDocScanner.clearScannedDocs()
   })
 
-  it('only shows definition on hovering global variable declaration syntax for bitbake variables after scanning the docs', async () => {
+  it('shows definition on hovering variable in variable assignment syntax or in variable expansion syntax after scanning the docs', async () => {
     bitBakeDocScanner.parseBitbakeVariablesFile()
     await analyzer.analyze({
       uri: DUMMY_URI,
       document: FIXTURE_DOCUMENT.HOVER
     })
 
-    const shouldShow = await onHoverHandler({
+    const shouldShow1 = await onHoverHandler({
       textDocument: {
         uri: DUMMY_URI
       },
       position: {
         line: 1,
         character: 1
+      }
+    })
+
+    const shouldShow2 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 2,
+        character: 12
+      }
+    })
+
+    const shouldShow3 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 3,
+        character: 9
       }
     })
 
@@ -72,7 +92,21 @@ describe('on hover', () => {
       }
     })
 
-    expect(shouldShow).toEqual({
+    expect(shouldShow1).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: '**DESCRIPTION**\n___\n   A long description for the recipe.\n\n'
+      }
+    })
+
+    expect(shouldShow2).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: '**DESCRIPTION**\n___\n   A long description for the recipe.\n\n'
+      }
+    })
+
+    expect(shouldShow3).toEqual({
       contents: {
         kind: 'markdown',
         value: '**DESCRIPTION**\n___\n   A long description for the recipe.\n\n'

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -16,9 +16,9 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
     return null
   }
   // Show documentation of a bitbake variable
-  // Triggers only on global declaration expressions like "VAR = 'foo'" but skip the ones like "python VAR(){}"
-  const wordIsGlobalDeclarationAndVariableName: boolean = analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)
-  if (wordIsGlobalDeclarationAndVariableName) {
+  // Triggers on global declaration expressions like "VAR = 'foo'" and inside variable expansion like "FOO = ${VAR}" but skip the ones like "python VAR(){}"
+  const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isVariableExpansion(textDocument.uri, position.line, position.character)
+  if (canShowHoverDefinitionForVariableName) {
     const found = bitBakeDocScanner.bitbakeVariableInfo.find((item) => item.name === word)
     if (found === undefined) {
       logger.debug(`[onHover] Not a bitbake variable: ${word}`)


### PR DESCRIPTION
1. Add hover definition on variables in **variable expansion syntax**
2. Hover definition on variables inside the functions is on hold until the embedded language service is done.

~~This branch rebased `Feature-10412-add-variables-from-yocto-docs` so it should be merged after [PR/59](https://github.com/savoirfairelinux/vscode-bitbake/pull/59)~~ _merged_
