### PR TITLE
Enable semanticTokensProvider, fix bug, update tests etc

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,14 @@
         "path": "./syntaxes/bitbake.tmLanguage.json"
       }
     ],
+    "semanticTokenScopes": [
+      {
+        "language": "bitbake",
+        "scopes": {
+          "operator.readonly": ["keyword.other.bitbake-operator.bb"]
+        }
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "BitBake",

--- a/client/syntaxes/bitbake.tmLanguage.json
+++ b/client/syntaxes/bitbake.tmLanguage.json
@@ -22,6 +22,9 @@
             "include": "#comment"
         },
         {
+            "include": "#inline-python"
+        },
+        {
             "include": "#variable-expansion"
         },
         {
@@ -101,6 +104,9 @@
                             "name": "constant.character.escape.bb"
                         },
                         {
+                            "include": "#inline-python"
+                        },
+                        {
                             "include": "#variable-expansion"
                         }
                     ]
@@ -110,6 +116,13 @@
                     "begin": "(')",
                     "end": "(')",
                     "patterns": [
+                        {
+                            "match": "\\\\'",
+                            "name": "constant.character.escape.bb"
+                        },
+                        {
+                            "include": "#inline-python"
+                        },
                         {
                             "include": "#variable-expansion"
                         }
@@ -149,6 +162,7 @@
             }
         },
         "variable-expansion": {
+            "name": "variable.other.names.bb",
             "begin": "(\\$\\{)",
             "beginCaptures": {
                 "1": {
@@ -160,12 +174,26 @@
                 "1": {
                     "name": "punctuation.definition.template-expression.end.bb"
                 }
+            }
+        },
+        "inline-python": {
+            "begin": "(\\$\\{(@))",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.template-expression.end.bb"
+                },
+                "2": {
+                    "name": "entity.name.function.decorator.python.bb"
+                }
+                
+            },
+            "end": "(\\})",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.template-expression.end.bb"
+                }
             },
             "patterns": [
-                {
-                    "match": "(@)",
-                    "name": "entity.name.function.decorator.python.bb"
-                },
                 {
                     "include": "#operator"
                 },

--- a/client/test/grammars/snaps/strings.bb
+++ b/client/test/grammars/snaps/strings.bb
@@ -45,4 +45,6 @@ inherit ${@ 'classname' if condition else ''}
 
 INHERIT += "autotools pkgconfig"
 
-MYVAR = "This string contains literal \" and it should work"
+MYVAR = "This string contains escaped double quote \" and it should not break the highlight"
+
+MYVAR = 'This string contains escaped single quote \' and it should not break the highlight'

--- a/client/test/grammars/snaps/variables.bb
+++ b/client/test/grammars/snaps/variables.bb
@@ -23,3 +23,5 @@ export ENV_VARIABLE = "variable-value"
 KBRANCH:qemuarm = "standard/arm-versatile-926ejs"
 
 DEPENDS:append:machine = "libmad"
+# This expression is not referencing a variable nor an inline python statement
+PN = "${bb.parse.vars_from_file(d.getVar('FILE', False),d)[0] or 'defaultpkgname'}"

--- a/client/test/grammars/test-cases/functions.bb
+++ b/client/test/grammars/test-cases/functions.bb
@@ -34,6 +34,7 @@
 >}
  
 >PN = "${@bb.parse.vars_from_file(d.getVar('FILE', False),d)[0] or 'defaultpkgname'}"
+#        ^ source.bb string.quoted.double.bb punctuation.definition.template-expression.end.bb entity.name.function.decorator.python.bb
 #                  ^^^^^^^^^^^^^^ source.bb string.quoted.double.bb entity.name.function.python.bb
 #                                   ^^^^^^ source.bb string.quoted.double.bb entity.name.function.python.bb
  

--- a/client/test/grammars/test-cases/strings.bb
+++ b/client/test/grammars/test-cases/strings.bb
@@ -123,6 +123,16 @@
 #            ^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.double.bb
 #                               ^ source.bb string.quoted.double.bb
 
->MYVAR = "This string contains literal \" and it should work"
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.double.bb
-#                                      ^^ source.bb string.quoted.double.bb constant.character.escape.bb 
+>MYVAR = "This string contains escaped double quote \" and it should not break the highlight"
+#        ^ source.bb string.quoted.double.bb
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.double.bb
+#                                                   ^^ source.bb string.quoted.double.bb constant.character.escape.bb
+#                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.double.bb
+#                                                                                           ^ source.bb string.quoted.double.bb
+
+>MYVAR = 'This string contains escaped single quote \' and it should not break the highlight'
+#        ^ source.bb string.quoted.single.bb
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.single.bb
+#                                                   ^^ source.bb string.quoted.single.bb constant.character.escape.bb
+#                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.single.bb
+#                                                                                           ^ source.bb string.quoted.single.bb

--- a/client/test/grammars/test-cases/variables.bb
+++ b/client/test/grammars/test-cases/variables.bb
@@ -49,3 +49,9 @@
 
 >DEPENDS:append:machine = "libmad"
 #^^^^^^^ source.bb variable.other.names.bb
+
+># This expression is not referencing a variable nor an inline python statement
+>PN = "${bb.parse.vars_from_file(d.getVar('FILE', False),d)[0] or 'defaultpkgname'}"
+#      ^^ source.bb string.quoted.double.bb variable.other.names.bb punctuation.definition.template-expression.begin.bb
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.double.bb variable.other.names.bb
+#                                                                                 ^ source.bb string.quoted.double.bb variable.other.names.bb punctuation.definition.template-expression.end.bb

--- a/server/src/__tests__/fixtures/fixtures.ts
+++ b/server/src/__tests__/fixtures/fixtures.ts
@@ -31,7 +31,8 @@ export const FIXTURE_URI = {
   COMPLETION: `file://${path.join(FIXTURE_FOLDER, 'completion.bb')}`,
   HOVER: `file://${path.join(FIXTURE_FOLDER, 'hover.bb')}`,
   DEFINITION: `file://${path.join(FIXTURE_FOLDER, 'definition.bb')}`,
-  EMBEDDED: `file://${path.join(FIXTURE_FOLDER, 'embedded.bb')}`
+  EMBEDDED: `file://${path.join(FIXTURE_FOLDER, 'embedded.bb')}`,
+  SEMANTIC_TOKENS: `file://${path.join(FIXTURE_FOLDER, 'semanticTokens.bb')}`
 }
 
 export const FIXTURE_DOCUMENT: Record<FIXTURE_URI_KEY, TextDocument> = (

--- a/server/src/__tests__/fixtures/semanticTokens.bb
+++ b/server/src/__tests__/fixtures/semanticTokens.bb
@@ -1,0 +1,14 @@
+FOO = 'FOO'
+
+MYVAR:append = '${FOO}'
+
+do_build () {
+    echo 'do build'
+}
+
+python hello(){
+    print('hello')
+}
+
+def getDay():
+    print('Woo, it\'s Friday!')

--- a/server/src/__tests__/semanticTokens.test.ts
+++ b/server/src/__tests__/semanticTokens.test.ts
@@ -1,0 +1,81 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { analyzer } from '../tree-sitter/analyzer'
+import { generateParser } from '../tree-sitter/parser'
+import { getParsedTokens, TOKEN_LEGEND } from '../semanticTokensProvider'
+import { FIXTURE_DOCUMENT } from './fixtures/fixtures'
+
+const DUMMY_URI = 'dummy_uri'
+
+describe('Semantic tokens', () => {
+  beforeAll(async () => {
+    if (!analyzer.hasParser()) {
+      const parser = await generateParser()
+      analyzer.initialize(parser)
+    }
+    analyzer.resetAnalyzedDocuments()
+  })
+
+  beforeEach(() => {
+    analyzer.resetAnalyzedDocuments()
+  })
+
+  it('gives approriate semantic tokens to symbols', async () => {
+    await analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.SEMANTIC_TOKENS
+    })
+
+    const result = getParsedTokens(DUMMY_URI)
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          line: 0,
+          startCharacter: 0,
+          length: 3,
+          tokenType: TOKEN_LEGEND.types.variable,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+        },
+        {
+          line: 2,
+          startCharacter: 18,
+          length: 3,
+          tokenType: TOKEN_LEGEND.types.variable,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+        },
+        {
+          line: 2,
+          startCharacter: 5,
+          length: 7,
+          tokenType: TOKEN_LEGEND.types.operator,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.readonly]
+        },
+        {
+          line: 4,
+          startCharacter: 0,
+          length: 8,
+          tokenType: TOKEN_LEGEND.types.function,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+        },
+        {
+          line: 8,
+          startCharacter: 7,
+          length: 5,
+          tokenType: TOKEN_LEGEND.types.function,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+        },
+        {
+          line: 12,
+          startCharacter: 4,
+          length: 6,
+          tokenType: TOKEN_LEGEND.types.function,
+          tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+        }
+      ])
+    )
+  })
+})

--- a/server/src/semanticTokensProvider.ts
+++ b/server/src/semanticTokensProvider.ts
@@ -1,0 +1,142 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { type SemanticTokens, SemanticTokensBuilder, type SemanticTokensLegend } from 'vscode-languageserver/node'
+import { logger } from './lib/src/utils/OutputLogger'
+import { analyzer } from './tree-sitter/analyzer'
+import * as TreeSitterUtils from './tree-sitter/utils'
+import { type SyntaxNode } from 'web-tree-sitter'
+
+interface ParsedToken {
+  line: number
+  startCharacter: number
+  length: number
+  tokenType: string
+  tokenModifiers: string[]
+}
+
+const tokenTypes = new Map<string, number>()
+const tokenModifiers = new Map<string, number>()
+
+// https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide
+export const TOKEN_LEGEND = {
+  types: {
+    function: 'function',
+    variable: 'variable',
+    parameter: 'parameter',
+    class: 'class',
+    number: 'number',
+    operator: 'operator',
+    string: 'string',
+    keyword: 'keyword'
+  },
+  modifiers: {
+    declaration: 'declaration',
+    deprecated: 'deprecated',
+    modification: 'modification',
+    readonly: 'readonly'
+  }
+}
+
+const generateSemanticTokensLegend = (): SemanticTokensLegend => {
+  const tokenTypesLegend = [
+    ...Object.keys(TOKEN_LEGEND.types)
+  ]
+  tokenTypesLegend.forEach((tokenType, index) => tokenTypes.set(tokenType, index))
+
+  const tokenModifiersLegend = [
+    ...Object.keys(TOKEN_LEGEND.modifiers)
+  ]
+  tokenModifiersLegend.forEach((tokenModifier, index) => tokenModifiers.set(tokenModifier, index))
+
+  return { tokenTypes: tokenTypesLegend, tokenModifiers: tokenModifiersLegend }
+}
+
+export const legend: SemanticTokensLegend = generateSemanticTokensLegend()
+
+// Check node_modules/@types/vscode/index.d.ts for more encoding details
+function encodeTokenType (tokenType: string): number {
+  if (tokenTypes.has(tokenType)) {
+    return Number(tokenTypes.get(tokenType))
+  } else if (tokenType === 'notInLegend') {
+    return tokenTypes.size + 2
+  }
+  return 0
+}
+
+function encodeTokenModifiers (strTokenModifiers: string[]): number {
+  let result = 0
+  for (let i = 0; i < strTokenModifiers.length; i++) {
+    const tokenModifier = strTokenModifiers[i]
+    if (tokenModifiers.has(tokenModifier)) {
+      result = result | (1 << Number(tokenModifiers.get(tokenModifier)))
+    } else if (tokenModifier === 'notInLegend') {
+      result = result | (1 << tokenModifiers.size + 2)
+    }
+  }
+  return result
+}
+
+export function getParsedTokens (uri: string): ParsedToken[] {
+  const resultTokens: ParsedToken[] = []
+  const Tree = analyzer.getParsedTreeForUri(uri)
+  if (Tree === undefined) {
+    logger.warn(`[getSemanticTokens] Syntax tree not found for ${uri}`)
+    return []
+  }
+
+  TreeSitterUtils.forEach(Tree.rootNode, (node: SyntaxNode) => {
+    const nodeRange = {
+      line: node.startPosition.row,
+      startCharacter: node.startPosition.column,
+      length: Math.max(node.endPosition.column - node.startPosition.column, 0)
+    }
+
+    if (TreeSitterUtils.isVariableReference(node)) {
+      resultTokens.push({
+        ...nodeRange,
+        tokenType: TOKEN_LEGEND.types.variable,
+        tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+      })
+    }
+
+    if (TreeSitterUtils.isOverride(node)) {
+      resultTokens.push({
+        ...nodeRange,
+        // This scope is customized in package.json "operator.readonly"
+        tokenType: TOKEN_LEGEND.types.operator,
+        tokenModifiers: [TOKEN_LEGEND.modifiers.readonly]
+      })
+    }
+
+    if (TreeSitterUtils.isFunctionIdentifier(node)) {
+      resultTokens.push({
+        ...nodeRange,
+        tokenType: TOKEN_LEGEND.types.function,
+        tokenModifiers: [TOKEN_LEGEND.modifiers.declaration]
+      })
+    }
+
+    // Traverse every node
+    return true
+  })
+
+  return resultTokens
+}
+
+export function getSemanticTokens (uri: string): SemanticTokens {
+  const resultTokens: ParsedToken[] = getParsedTokens(uri)
+  const builder = new SemanticTokensBuilder()
+  resultTokens.forEach(token => {
+    builder.push(
+      token.line,
+      token.startCharacter,
+      token.length,
+      encodeTokenType(token.tokenType),
+      encodeTokenModifiers(token.tokenModifiers)
+    )
+  })
+  return builder.build()
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -31,6 +31,7 @@ import { generateEmbeddedLanguageDocs, getEmbeddedLanguageDocInfosOnPosition } f
 import { embeddedLanguageDocsManager } from './embedded-languages/documents-manager'
 import { RequestMethod, type RequestParams, type RequestResult } from './lib/src/types/requests'
 import { NotificationMethod, type NotificationParams } from './lib/src/types/notifications'
+import { getSemanticTokens, legend } from './semanticTokensProvider'
 // Create a connection for the server. The connection uses Node's IPC as a transport
 const connection: Connection = createConnection(ProposedFeatures.all)
 const documents = new TextDocuments<TextDocument>(TextDocument)
@@ -68,7 +69,11 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
           'bitbake.rescan-project'
         ]
       },
-      hoverProvider: true
+      hoverProvider: true,
+      semanticTokensProvider: {
+        legend,
+        full: true
+      }
     }
   }
 })
@@ -141,6 +146,11 @@ connection.onRequest(
     return getEmbeddedLanguageDocInfosOnPosition(uriString, position)
   }
 )
+// This request method 'textDocument/semanticTokens' will be sent when semanticTokensProvider capability is enabled
+connection.onRequest('textDocument/semanticTokens/full', ({ textDocument }) => {
+  logger.debug(`[OnRequest] <textDocument/semanticTokens/full> Document uri: ${textDocument.uri}`)
+  return getSemanticTokens(textDocument.uri)
+})
 
 connection.onNotification(
   NotificationMethod.FilenameChanged,

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -112,6 +112,10 @@ export default class Analyzer {
     return []
   }
 
+  public getParsedTreeForUri (uri: string): Tree | undefined {
+    return this.uriToAnalyzedDocument[uri]?.tree
+  }
+
   /**
    * Find the full word at the given point.
    */

--- a/server/src/tree-sitter/utils.ts
+++ b/server/src/tree-sitter/utils.ts
@@ -52,10 +52,41 @@ export function isShellDefinition (n: SyntaxNode): boolean {
   return n.type === 'function_definition'
 }
 
-export function isReference (n: SyntaxNode): boolean {
+export function isVariableReference (n: SyntaxNode): boolean {
   switch (n.type) {
-    case 'variable_assignment': // Currently, the tree doesn't have a unique type for variable reference neither for function reference
-      return true
+    case 'identifier':
+      return n?.parent?.type === 'variable_assignment' || n?.parent?.type === 'variable_expansion'
+    default:
+      return false
+  }
+}
+
+export function isOverride (n: SyntaxNode): boolean {
+  const parentTypes = [
+    'variable_assignment',
+    'function_definition',
+    'anonymous_python_function',
+    'python_function_definition'
+  ]
+  const parentType = n?.parent?.type
+  switch (n.type) {
+    case 'override':
+      if (parentType !== undefined) {
+        return parentTypes.includes(parentType)
+      }
+      return false
+    default:
+      return false
+  }
+}
+
+export function isFunctionIdentifier (n: SyntaxNode): boolean {
+  switch (n.type) {
+    case 'identifier':
+      return n?.parent?.type === 'function_definition' ||
+      n?.parent?.type === 'anonymous_python_function'
+    case 'python_identifier':
+      return n?.parent?.type === 'python_function_definition'
     default:
       return false
   }


### PR DESCRIPTION
1. Enabled semanticTokensProvider at the server side.
Example results:
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/01ef6a63-eda0-48d2-8c37-22a5bf8098b6)
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/f3fd6e6b-0c6d-4150-8883-a5c285a6a2be)
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/0cdb3362-831a-4b07-824d-868d9378e560)
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/258ac204-a7e8-4e61-bd88-b6c2787a6843)

3. Fixed the bug where non-inline-python syntax is highlighted as python
Example results:
With `@`
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/fe4d1db6-494c-4869-903c-2ae21ba6849b)
Without `@`
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/e704d3d7-dc3d-45a3-aed1-0bae6bed649e)

4. Added and updated related tests


