### PR TITLE
Improve embedded language support

### DIFF
--- a/client/src/language/languageClient.ts
+++ b/client/src/language/languageClient.ts
@@ -21,6 +21,7 @@ import {
 import { NotificationMethod, type NotificationParams } from '../lib/src/types/notifications'
 import { middlewareProvideCompletion } from './middlewareCompletion'
 import { middlewareProvideHover } from './middlewareHover'
+import { requestsManager } from './RequestManager'
 
 const notifyFileRenameChanged = async (
   client: LanguageClient,
@@ -77,6 +78,7 @@ export async function activateLanguageServer (context: ExtensionContext): Promis
 
   // Create the language client and start the client.
   const client: LanguageClient = new LanguageClient('bitbake', 'Bitbake Language Server', serverOptions, clientOptions)
+  requestsManager.client = client
 
   client.onRequest('custom/verifyConfigurationFileAssociation', async (param) => {
     if (param.filePath?.endsWith('.conf') === true) {

--- a/client/src/language/middlewareCompletion.ts
+++ b/client/src/language/middlewareCompletion.ts
@@ -7,16 +7,14 @@ import { type CompletionList, Uri, commands } from 'vscode'
 import { type CompletionMiddleware } from 'vscode-languageclient/node'
 
 import { requestsManager } from './RequestManager'
+import { getEmbeddedLanguageDocPosition } from './utils'
 
 export const middlewareProvideCompletion: CompletionMiddleware['provideCompletionItem'] = async (document, position, context, token, next) => {
   const embeddedLanguageDocInfos = await requestsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), position)
   if (embeddedLanguageDocInfos === undefined) {
     return await next(document, position, context, token)
   }
-  const adjustedPosition = {
-    ...position,
-    line: position.line + embeddedLanguageDocInfos.lineOffset
-  }
+  const adjustedPosition = await getEmbeddedLanguageDocPosition(document, embeddedLanguageDocInfos, position)
   const vdocUri = Uri.parse(embeddedLanguageDocInfos.uri)
   const result = await commands.executeCommand<CompletionList>(
     'vscode.executeCompletionItemProvider',

--- a/client/src/language/middlewareHover.ts
+++ b/client/src/language/middlewareHover.ts
@@ -7,16 +7,14 @@ import { type HoverMiddleware } from 'vscode-languageclient'
 import { type Hover, Uri, commands } from 'vscode'
 
 import { requestsManager } from './RequestManager'
+import { getEmbeddedLanguageDocPosition } from './utils'
 
 export const middlewareProvideHover: HoverMiddleware['provideHover'] = async (document, position, token, next) => {
   const embeddedLanguageDocInfos = await requestsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), position)
   if (embeddedLanguageDocInfos === undefined) {
     return await next(document, position, token)
   }
-  const adjustedPosition = {
-    character: position.character,
-    line: position.line + embeddedLanguageDocInfos.lineOffset
-  }
+  const adjustedPosition = await getEmbeddedLanguageDocPosition(document, embeddedLanguageDocInfos, position)
   const vdocUri = Uri.parse(embeddedLanguageDocInfos.uri)
   const result = await commands.executeCommand<Hover[]>(
     'vscode.executeHoverProvider',

--- a/client/src/language/utils.ts
+++ b/client/src/language/utils.ts
@@ -1,0 +1,19 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { type TextDocument, type Position, workspace } from 'vscode'
+
+import { type EmbeddedLanguageDocInfos } from '../lib/src/types/embedded-languages'
+
+export const getEmbeddedLanguageDocPosition = async (
+  originalTextDocument: TextDocument,
+  embeddedLanguageDocInfos: EmbeddedLanguageDocInfos,
+  originalPosition: Position
+): Promise<Position> => {
+  const originalOffset = originalTextDocument.offsetAt(originalPosition)
+  const embeddedLanguageDocOffset = embeddedLanguageDocInfos.characterIndexes[originalOffset]
+  const embeddedLanguageDoc = await workspace.openTextDocument(embeddedLanguageDocInfos.uri.replace('file://', ''))
+  return embeddedLanguageDoc.positionAt(embeddedLanguageDocOffset)
+}

--- a/client/src/lib/src/types/embedded-languages.ts
+++ b/client/src/lib/src/types/embedded-languages.ts
@@ -8,5 +8,5 @@ export type EmbeddedLanguageType = 'bash' | 'python'
 export interface EmbeddedLanguageDocInfos {
   uri: string
   language: EmbeddedLanguageType
-  lineOffset: number
+  characterIndexes: number[]
 }

--- a/server/src/__tests__/embedded-languages.test.ts
+++ b/server/src/__tests__/embedded-languages.test.ts
@@ -170,28 +170,28 @@ describe('Create Python embedded language content with imports', () => {
   test.each([
     [
       'with bb',
-      'python (){\n  bb.parse.vars_from_file("test")\n}',
-      'import bb\nfrom bb import parse\nbb.parse = parse\ndef ():\n  bb.parse.vars_from_file("test")\n '
+      'python(){\n  bb.parse.vars_from_file("test")\n}',
+      'import bb\nfrom bb import parse\nbb.parse = parse\ndef _ ():\n  bb.parse.vars_from_file("test")\n '
     ],
     [
       'with d',
-      'python (){\n  d.getVar("test")\n}',
-      'from bb import data_smart\nd = data_smart.DataSmart()\ndef ():\n  d.getVar("test")\n '
+      'python(){\n  d.getVar("test")\n}',
+      'from bb import data_smart\nd = data_smart.DataSmart()\ndef _ ():\n  d.getVar("test")\n '
     ],
     [
       'with e',
-      'python (){\n  e.data.getVar("test")\n}',
-      'from bb import data_smart\nd = data_smart.DataSmart()\nfrom bb import event\ne = event.Event()\ne.data = d\ndef ():\n  e.data.getVar("test")\n '
+      'python(){\n  e.data.getVar("test")\n}',
+      'from bb import data_smart\nd = data_smart.DataSmart()\nfrom bb import event\ne = event.Event()\ne.data = d\ndef _ ():\n  e.data.getVar("test")\n '
     ],
     [
       'with os',
-      'python (){\n  os.path.dirname("test")\n}',
-      'import os\ndef ():\n  os.path.dirname("test")\n '
+      'python(){\n  os.path.dirname("test")\n}',
+      'import os\ndef _ ():\n  os.path.dirname("test")\n '
     ],
     [
       'with combination (d and bb)',
-      'python (){\n  d.getVar("test")\n  bb.parse.vars_from_file("test")\n}',
-      'from bb import data_smart\nd = data_smart.DataSmart()\nimport bb\nfrom bb import parse\nbb.parse = parse\ndef ():\n  d.getVar("test")\n  bb.parse.vars_from_file("test")\n '
+      'python(){\n  d.getVar("test")\n  bb.parse.vars_from_file("test")\n}',
+      'from bb import data_smart\nd = data_smart.DataSmart()\nimport bb\nfrom bb import parse\nbb.parse = parse\ndef _ ():\n  d.getVar("test")\n  bb.parse.vars_from_file("test")\n '
     ]
   ])('%s', async (description, input, result) => {
     const embeddedContent = await createEmbeddedContent(input, 'python')

--- a/server/src/__tests__/embedded-languages.test.ts
+++ b/server/src/__tests__/embedded-languages.test.ts
@@ -115,41 +115,42 @@ describe('Create Python embedded language content with inline Python', () => {
 
   test.each([
     [
-      'with single quotes',
+      'basic',
       // eslint-disable-next-line no-template-curly-in-string
-      "FOO = '${@\"BAR\"}'\n",
-      "FOO = f'''{\"BAR\"}'''\n"
+      'FOO = \'${@"BAR"}\'\n',
+      '         \n\n"BAR"\n \n'
     ],
     [
-      'with double quotes',
+      'with spacing',
       // eslint-disable-next-line no-template-curly-in-string
-      'FOO = "${@\'BAR\'}"\n',
-      'FOO = f"""{\'BAR\'}"""\n'
-    ],
-    [
-      'with bitbake operator',
-      // eslint-disable-next-line no-template-curly-in-string
-      'FOO ??= "${@\'BAR\'}"\n',
-      'FOO = f"""{\'BAR\'}"""\n'
-    ],
-    [
-      'with override',
-      // eslint-disable-next-line no-template-curly-in-string
-      'FOO:prepend = "${@\'BAR\'}"\n',
-      'FOO         = f"""{\'BAR\'}"""\n'
-    ],
-    [
-      'with complex spacing',
-      // eslint-disable-next-line no-template-curly-in-string
-      'FOO  ?=   "  BAR  ${@  \'BAR\'   }  BAR  "\n',
-      'FOO  =   f"""  BAR  {  \'BAR\'   }  BAR  """\n'
+      'FOO = \'${@  "BAR"  }\'\n',
+      '         \n  \n"BAR"  \n \n'
     ],
     [
       'multiline',
       // eslint-disable-next-line no-template-curly-in-string
-      'FOO = "${@\'BAR\'} \\\n1 \\\n2"\n',
-      'FOO = f"""{\'BAR\'} \n1 \n2"""\n'
+      'FOO = \'${@"BAR"}\' \\\n1 \\\n2"\n',
+      '         \n\n"BAR"\n   \n   \n  \n'
+    ],
+    [
+      'with two embedded python regions',
+      // eslint-disable-next-line no-template-curly-in-string
+      'FOO = \'${@"BAR"}${@"BAR"}\'\n',
+      '         \n\n"BAR"\n  \n\n"BAR"\n \n'
+    ],
+    [
+      'without surrounding quotes',
+      // eslint-disable-next-line no-template-curly-in-string
+      'inherit ${@"test"}\n',
+      '          \n\n"test"\n\n'
     ]
+    /* // This is not yet supported by tree-sitter
+    [
+      'inside bash function',
+      // eslint-disable-next-line no-template-curly-in-string
+      'foo(){\necho ${@"bar"}\n}\n',
+      '      \n       \n"bar"\n\n \n'
+    ] */
   ])('%s', async (description, input, result) => {
     const embeddedContent = await createEmbeddedContent(input, 'python')
     expect(embeddedContent).toEqual(result)

--- a/server/src/__tests__/embedded-languages.test.ts
+++ b/server/src/__tests__/embedded-languages.test.ts
@@ -103,6 +103,43 @@ describe('Embedded Language Documents file management', () => {
   })
 })
 
+describe('Create various basic embedded python documents', () => {
+  beforeAll(async () => {
+    if (!analyzer.hasParser()) {
+      const parser = await generateParser()
+      analyzer.initialize(parser)
+    }
+    analyzer.resetAnalyzedDocuments()
+    await embeddedLanguageDocsManager.setStoragePath(__dirname)
+  })
+
+  test.each([
+    [
+      'anonymous',
+      'python(){\n  pass\n}',
+      'def _ ():\n  pass\n '
+    ],
+    [
+      'named with python keyword',
+      'python foo (){\n  pass\n}',
+      'def foo ():\n  pass\n '
+    ],
+    [
+      'empty',
+      'python(){\n}',
+      'def _ ():\n  pass\n '
+    ],
+    [
+      'with def keyword',
+      'def foo():\n  pass',
+      'def foo():\n  pass'
+    ]
+  ])('%s', async (description, input, result) => {
+    const embeddedContent = await createEmbeddedContent(input, 'python')
+    expect(embeddedContent).toEqual(result)
+  })
+})
+
 describe('Create Python embedded language content with inline Python', () => {
   beforeAll(async () => {
     if (!analyzer.hasParser()) {

--- a/server/src/__tests__/embedded-languages.test.ts
+++ b/server/src/__tests__/embedded-languages.test.ts
@@ -117,32 +117,32 @@ describe('Create Python embedded language content with inline Python', () => {
     [
       'basic',
       // eslint-disable-next-line no-template-curly-in-string
-      'FOO = \'${@"BAR"}\'\n',
-      '         \n\n"BAR"\n \n'
+      'FOO = \'${@"BAR"}\'',
+      '         \n\n"BAR"\n '
     ],
     [
       'with spacing',
       // eslint-disable-next-line no-template-curly-in-string
-      'FOO = \'${@  "BAR"  }\'\n',
-      '         \n  \n"BAR"  \n \n'
+      'FOO = \'${@  "BAR"  }\'',
+      '         \n  \n"BAR"  \n '
     ],
     [
       'multiline',
       // eslint-disable-next-line no-template-curly-in-string
-      'FOO = \'${@"BAR"}\' \\\n1 \\\n2"\n',
-      '         \n\n"BAR"\n   \n   \n  \n'
+      'FOO = \'${@"BAR"}\' \\\n1 \\\n2"',
+      '         \n\n"BAR"\n   \n   \n  '
     ],
     [
       'with two embedded python regions',
       // eslint-disable-next-line no-template-curly-in-string
-      'FOO = \'${@"BAR"}${@"BAR"}\'\n',
-      '         \n\n"BAR"\n  \n\n"BAR"\n \n'
+      'FOO = \'${@"BAR"}${@"BAR"}\'',
+      '         \n\n"BAR"\n  \n\n"BAR"\n '
     ],
     [
       'without surrounding quotes',
       // eslint-disable-next-line no-template-curly-in-string
-      'inherit ${@"test"}\n',
-      '          \n\n"test"\n\n'
+      'inherit ${@"test"}',
+      '          \n\n"test"\n'
     ]
     /* // This is not yet supported by tree-sitter
     [
@@ -170,28 +170,28 @@ describe('Create Python embedded language content with imports', () => {
   test.each([
     [
       'with bb',
-      'python (){\n  bb.parse.vars_from_file("test")\n}\n',
-      'import bb\nfrom bb import parse\nbb.parse = parse\ndef ():\n  bb.parse.vars_from_file("test")\n \n'
+      'python (){\n  bb.parse.vars_from_file("test")\n}',
+      'import bb\nfrom bb import parse\nbb.parse = parse\ndef ():\n  bb.parse.vars_from_file("test")\n '
     ],
     [
       'with d',
-      'python (){\n  d.getVar("test")\n}\n',
-      'from bb import data_smart\nd = data_smart.DataSmart()\ndef ():\n  d.getVar("test")\n \n'
+      'python (){\n  d.getVar("test")\n}',
+      'from bb import data_smart\nd = data_smart.DataSmart()\ndef ():\n  d.getVar("test")\n '
     ],
     [
       'with e',
-      'python (){\n  e.data.getVar("test")\n}\n',
-      'from bb import data_smart\nd = data_smart.DataSmart()\nfrom bb import event\ne = event.Event()\ne.data = d\ndef ():\n  e.data.getVar("test")\n \n'
+      'python (){\n  e.data.getVar("test")\n}',
+      'from bb import data_smart\nd = data_smart.DataSmart()\nfrom bb import event\ne = event.Event()\ne.data = d\ndef ():\n  e.data.getVar("test")\n '
     ],
     [
       'with os',
-      'python (){\n  os.path.dirname("test")\n}\n',
-      'import os\ndef ():\n  os.path.dirname("test")\n \n'
+      'python (){\n  os.path.dirname("test")\n}',
+      'import os\ndef ():\n  os.path.dirname("test")\n '
     ],
     [
       'with combination (d and bb)',
-      'python (){\n  d.getVar("test")\n  bb.parse.vars_from_file("test")\n}\n',
-      'from bb import data_smart\nd = data_smart.DataSmart()\nimport bb\nfrom bb import parse\nbb.parse = parse\ndef ():\n  d.getVar("test")\n  bb.parse.vars_from_file("test")\n \n'
+      'python (){\n  d.getVar("test")\n  bb.parse.vars_from_file("test")\n}',
+      'from bb import data_smart\nd = data_smart.DataSmart()\nimport bb\nfrom bb import parse\nbb.parse = parse\ndef ():\n  d.getVar("test")\n  bb.parse.vars_from_file("test")\n '
     ]
   ])('%s', async (description, input, result) => {
     const embeddedContent = await createEmbeddedContent(input, 'python')

--- a/server/src/__tests__/embedded-languages.test.ts
+++ b/server/src/__tests__/embedded-languages.test.ts
@@ -133,6 +133,12 @@ describe('Create Python embedded language content with inline Python', () => {
       'FOO = f"""{\'BAR\'}"""\n'
     ],
     [
+      'with override',
+      // eslint-disable-next-line no-template-curly-in-string
+      'FOO:prepend = "${@\'BAR\'}"\n',
+      'FOO         = f"""{\'BAR\'}"""\n'
+    ],
+    [
       'with complex spacing',
       // eslint-disable-next-line no-template-curly-in-string
       'FOO  ?=   "  BAR  ${@  \'BAR\'   }  BAR  "\n',

--- a/server/src/embedded-languages/python-support.ts
+++ b/server/src/embedded-languages/python-support.ts
@@ -44,7 +44,7 @@ const handlePythonFunctionDefinition = (node: SyntaxNode, embeddedLanguageDoc: E
   insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, node.startIndex, node.endIndex, node.text)
   node.children.forEach((child) => {
     if (child.type === 'block') {
-      handleBlockNode(child, imports)
+      handleBlockNode(child, embeddedLanguageDoc, imports)
     }
   })
 }
@@ -72,7 +72,7 @@ const handleAnonymousPythonFunction = (node: SyntaxNode, embeddedLanguageDoc: Em
         insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, child.startIndex, child.endIndex, ' ')
         break
       case 'block':
-        handleBlockNode(child, imports)
+        handleBlockNode(child, embeddedLanguageDoc, imports)
         break
       default:
         break
@@ -98,10 +98,17 @@ const handleInlinePythonNode = (inlinePythonNode: SyntaxNode, embeddedLanguageDo
   insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, pythonContentNode.startIndex, pythonContentNode.startIndex, '\n') // prevent trailing spaces
   insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, pythonContentNode.startIndex, pythonContentNode.endIndex, pythonContentNode.text)
   insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, closingNode.startIndex, closingNode.endIndex, '\n')
-  handleBlockNode(pythonContentNode, imports)
+  handleBlockNode(pythonContentNode, embeddedLanguageDoc, imports)
 }
 
-const handleBlockNode = (blockNode: SyntaxNode, imports: Set<string>): void => {
+const handleBlockNode = (blockNode: SyntaxNode, embeddedLanguageDoc: EmbeddedLanguageDoc, imports: Set<string>): void => {
+  if (blockNode.text === '') {
+    insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, blockNode.startIndex, blockNode.endIndex, '\n  pass')
+  }
+  handleImports(blockNode, imports)
+}
+
+const handleImports = (blockNode: SyntaxNode, imports: Set<string>): void => {
   const importBb = (bbNode: SyntaxNode): void => {
     if (bbNode.nextSibling?.type === '.' && bbNode.nextNamedSibling?.type === 'python_identifier') {
       const importName = bbNode.nextNamedSibling.text

--- a/server/src/embedded-languages/python-support.ts
+++ b/server/src/embedded-languages/python-support.ts
@@ -4,32 +4,146 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { type TextDocument } from 'vscode-languageserver-textdocument'
-import { replaceTextForSpaces } from './utils'
+import { type SyntaxNode } from 'web-tree-sitter'
 
 import { analyzer } from '../tree-sitter/analyzer'
+import * as TreeSitterUtils from '../tree-sitter/utils'
+
 import { embeddedLanguageDocsManager } from './documents-manager'
-import { type EmbeddedLanguageDocInfos } from '../lib/src/types/embedded-languages'
+import { logger } from '../lib/src/utils/OutputLogger'
+import { type EmbeddedLanguageDoc, insertTextIntoEmbeddedLanguageDoc, initEmbeddedLanguageDoc, isQuotes } from './utils'
 
 export const generatePythonEmbeddedLanguageDoc = async (textDocument: TextDocument): Promise<void> => {
-  const pythonRegions = analyzer.getPythonRegions(textDocument.uri)
-  const documentAsText = textDocument.getText().split(/\r?\n/g)
-  const embeddedLanguageDocAsText = replaceTextForSpaces(documentAsText)
-  pythonRegions.forEach((region) => {
-    const { start, end } = region.location.range
-    const declarationLine = documentAsText[start.line]
-      .replace(/^(\s*fakeroot)?\s*python/, 'def')
-      .replace(/:(append|prepend|remove)/, (_match, p1) => { return `_${p1}` })
-      .replace('{', ':')
-    embeddedLanguageDocAsText[start.line] = declarationLine
-    for (let i = start.line + 1; i < end.line; i++) {
-      embeddedLanguageDocAsText[i] = documentAsText[i]
+  const analyzedDocument = analyzer.getAnalyzedDocument(textDocument.uri)
+  if (analyzedDocument === undefined) {
+    return
+  }
+  const imports: string[] = ['import bb']
+  const embeddedLanguageDoc = initEmbeddedLanguageDoc(textDocument, 'python')
+  TreeSitterUtils.forEach(analyzedDocument.tree.rootNode, (node) => {
+    switch (node.type) {
+      case 'recipe':
+        return true
+      case 'python_function_definition':
+        handlePythonFunctionDefinition(node, embeddedLanguageDoc)
+        return false
+      case 'anonymous_python_function':
+        handleAnonymousPythonFunction(node, embeddedLanguageDoc)
+        return false
+      case 'variable_assignment': // Handle 'inline_python'
+        handleVariableAssigmentNode(node, embeddedLanguageDoc)
+        return false
+      default:
+        return false
     }
   })
-  embeddedLanguageDocAsText.unshift('import bb')
-  const content = embeddedLanguageDocAsText.join('\n')
-  const partialInfos: Omit<EmbeddedLanguageDocInfos, 'uri'> = {
-    language: 'python',
-    lineOffset: 1
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, 0, 0, imports.join('\n') + '\n')
+  await embeddedLanguageDocsManager.saveEmbeddedLanguageDoc(embeddedLanguageDoc)
+}
+
+const handlePythonFunctionDefinition = (node: SyntaxNode, embeddedLanguageDoc: EmbeddedLanguageDoc): void => {
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, node.startIndex, node.endIndex, node.text)
+}
+
+const handleAnonymousPythonFunction = (node: SyntaxNode, embeddedLanguageDoc: EmbeddedLanguageDoc): void => {
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, node.startIndex, node.endIndex, node.text)
+  node.children.forEach((child) => {
+    switch (child.type) {
+      case 'python':
+        insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, child.startIndex, child.endIndex, 'def')
+        break
+      case 'identifier':
+        break
+      case 'override':
+        insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, child.startIndex, child.endIndex, ' '.repeat(child.text.length))
+        break
+      case '{':
+        insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, child.startIndex, child.endIndex, ':')
+        break
+      case '}':
+        insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, child.startIndex, child.endIndex, ' ')
+        break
+      default:
+        break
+    }
+  })
+}
+
+const handleVariableAssigmentNode = (node: SyntaxNode, embeddedLanguageDoc: EmbeddedLanguageDoc): void => {
+  if (!TreeSitterUtils.containsInlinePython(node)) {
+    // We only care about inline python
+    return
   }
-  await embeddedLanguageDocsManager.saveEmbeddedLanguageDoc(textDocument.uri, content, partialInfos)
+
+  // Insert back the whole node, which we'll modify
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, node.startIndex, node.endIndex, node.text)
+
+  // Handle operator node such as '=', '??=', '+=', etc.
+  const operatorNode = node.child(1)
+  if (operatorNode === null) {
+    logger.warn('Unexpected variable_assignment node: operator is null')
+    return
+  }
+  // Replace the operator with one that will be valid for sure in Python. It does not matters whih one.
+  insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, operatorNode.startIndex, operatorNode.endIndex, '=')
+
+  const literalNode = node.child(2)
+  if (literalNode === null) {
+    logger.warn('Unexpected variable_assignment node: literal is null')
+    return
+  }
+  const handleLiteralNode = (literalNode: SyntaxNode): void => {
+    const stringNode = literalNode.child(0)
+    if (stringNode === null) {
+      logger.warn('Unexpected variable_assignment node: string is null')
+      return
+    }
+    const handleQuotesNode = (stringNode: SyntaxNode): void => {
+      const openingQuoteNode = stringNode.child(0)
+      const closingQuoteNode = stringNode.child(stringNode.childCount - 1)
+      if (openingQuoteNode === null || !isQuotes(openingQuoteNode?.text)) {
+        logger.warn(`Unexpected opening quote node: quote is ${openingQuoteNode?.text}}`)
+        return
+      }
+      if (closingQuoteNode === null || !isQuotes(closingQuoteNode?.text)) {
+        logger.warn(`Unexpected closing quote node: quote is ${closingQuoteNode?.text}}`)
+        return
+      }
+      const newQuotes = openingQuoteNode.text.repeat(3)
+      // Transform the string into a python f-string
+      insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, openingQuoteNode.startIndex, openingQuoteNode.endIndex, `f${newQuotes}`)
+      insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, closingQuoteNode.startIndex, closingQuoteNode.endIndex, newQuotes)
+    }
+    handleQuotesNode(stringNode)
+
+    const handleInlinePythonNode = (inlinePythonNode: SyntaxNode): void => {
+      const openingNode = inlinePythonNode.child(0)
+      if (openingNode?.type !== '${@') {
+        return
+      }
+      // Replace '${@' for '{', which is the f-string syntax
+      insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, openingNode.startIndex, openingNode.endIndex, '{')
+    }
+    const handleStringContentNode = (stringContentNode: SyntaxNode): void => {
+      // Remove all line continuation backslashes ('\')
+      for (const match of stringContentNode.text.matchAll(/\\\n/g)) {
+        if (match.index === undefined) {
+          continue
+        }
+        const startIndex = stringContentNode.startIndex + match.index
+        insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, startIndex, startIndex + 2, '\n')
+      }
+    }
+    TreeSitterUtils.forEach(stringNode, (child) => {
+      if (child.type === 'string') {
+        return true
+      } else if (child.type === 'inline_python') {
+        handleInlinePythonNode(child)
+      } else if (child.type === 'string_content') {
+        handleStringContentNode(child)
+      }
+      return false
+    })
+  }
+  handleLiteralNode(literalNode)
 }

--- a/server/src/embedded-languages/python-support.ts
+++ b/server/src/embedded-languages/python-support.ts
@@ -55,6 +55,10 @@ const handleAnonymousPythonFunction = (node: SyntaxNode, embeddedLanguageDoc: Em
     switch (child.type) {
       case 'python':
         insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, child.startIndex, child.endIndex, 'def')
+        if (child.nextSibling?.type === '(') {
+          // if there is no identfier, we add a dummy one
+          insertTextIntoEmbeddedLanguageDoc(embeddedLanguageDoc, child.endIndex, child.endIndex, ' _ ')
+        }
         break
       case 'identifier':
         break

--- a/server/src/embedded-languages/utils.ts
+++ b/server/src/embedded-languages/utils.ts
@@ -5,9 +5,18 @@
 
 import { type Position } from 'vscode-languageserver'
 import type * as LSP from 'vscode-languageserver/node'
+import { type TextDocument } from 'vscode-languageserver-textdocument'
 
 import { analyzer } from '../tree-sitter/analyzer'
 import { positionIsWithinRange } from '../utils/range'
+import { type EmbeddedLanguageType } from '../lib/src/types/embedded-languages'
+
+export interface EmbeddedLanguageDoc {
+  originalUri: string
+  language: EmbeddedLanguageType
+  content: string
+  characterIndexes: number[]
+}
 
 const isInsideRegion = (position: Position, region: LSP.SymbolInformation): boolean => {
   return positionIsWithinRange(position, region.location.range)
@@ -23,6 +32,47 @@ export const isInsidePythonRegion = (stringUri: string, position: Position): boo
   return pythonRegions.some((region) => isInsideRegion(position, region))
 }
 
-export const replaceTextForSpaces = (documentAsText: string[]): string[] => {
-  return documentAsText.map((line) => ' '.repeat(line.length))
+const replaceTextForSpaces = (text: string): string => {
+  return text.replace(/[^\r\n]+/g, (match) => ' '.repeat(match.length))
+}
+
+const initCharactersOffsetArrays = (length: number): number[] => {
+  return Array.from({ length }, (_, i) => i)
+}
+
+export const initEmbeddedLanguageDoc = (textDocument: TextDocument, language: EmbeddedLanguageType): EmbeddedLanguageDoc => {
+  return {
+    originalUri: textDocument.uri,
+    language,
+    content: replaceTextForSpaces(textDocument.getText()),
+    characterIndexes: initCharactersOffsetArrays(textDocument.getText().length)
+  }
+}
+
+const addCharacterOffset = (charactersOffsetArray: number[], character: number, offset: number): void => {
+  for (let i = character; i < charactersOffsetArray.length; i++) {
+    charactersOffsetArray[i] += offset
+  }
+}
+
+const insertTextBetweenIndexes = (inputString: string, start: number, end: number, replacementText: string): string => {
+  const beforeTarget = inputString.substring(0, start)
+  const afterTarget = inputString.substring(end)
+  return `${beforeTarget}${replacementText}${afterTarget}`
+}
+
+export const insertTextIntoEmbeddedLanguageDoc = (embeddedLanguageDoc: EmbeddedLanguageDoc, start: number, end: number, textToInsert: string): void => {
+  const adjustedStart = embeddedLanguageDoc.characterIndexes[start]
+  const adjustedEnd = embeddedLanguageDoc.characterIndexes[end]
+  embeddedLanguageDoc.content = insertTextBetweenIndexes(embeddedLanguageDoc.content, adjustedStart, adjustedEnd, textToInsert)
+  const previousLength = end - start
+  const newLength = textToInsert.length
+  const diff = newLength - previousLength
+  if (diff !== 0) {
+    addCharacterOffset(embeddedLanguageDoc.characterIndexes, end, diff)
+  }
+}
+
+export const isQuotes = (value: unknown): value is "'" | '"' => {
+  return value === '"' || value === "'"
 }

--- a/server/src/embedded-languages/utils.ts
+++ b/server/src/embedded-languages/utils.ts
@@ -37,7 +37,7 @@ const replaceTextForSpaces = (text: string): string => {
 }
 
 const initCharactersOffsetArrays = (length: number): number[] => {
-  return Array.from({ length }, (_, i) => i)
+  return Array.from({ length: length + 1 }, (_, i) => i)
 }
 
 export const initEmbeddedLanguageDoc = (textDocument: TextDocument, language: EmbeddedLanguageType): EmbeddedLanguageDoc => {

--- a/server/src/embedded-languages/utils.ts
+++ b/server/src/embedded-languages/utils.ts
@@ -61,6 +61,8 @@ const insertTextBetweenIndexes = (inputString: string, start: number, end: numbe
   return `${beforeTarget}${replacementText}${afterTarget}`
 }
 
+// Important constraint: Regions of the document on which the user interacts must keep the same size
+// Otherwise it will not be possible to map the cursor position from the original document to the embedded document
 export const insertTextIntoEmbeddedLanguageDoc = (embeddedLanguageDoc: EmbeddedLanguageDoc, start: number, end: number, textToInsert: string): void => {
   const adjustedStart = embeddedLanguageDoc.characterIndexes[start]
   const adjustedEnd = embeddedLanguageDoc.characterIndexes[end]
@@ -71,8 +73,4 @@ export const insertTextIntoEmbeddedLanguageDoc = (embeddedLanguageDoc: EmbeddedL
   if (diff !== 0) {
     addCharacterOffset(embeddedLanguageDoc.characterIndexes, end, diff)
   }
-}
-
-export const isQuotes = (value: unknown): value is "'" | '"' => {
-  return value === '"' || value === "'"
 }

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -38,6 +38,10 @@ export default class Analyzer {
     return this.uriToAnalyzedDocument[uri]?.document.getText().split(/\r?\n/g)
   }
 
+  public getAnalyzedDocument (uri: string): AnalyzedDocument | undefined {
+    return this.uriToAnalyzedDocument[uri]
+  }
+
   public initialize (parser: Parser): void {
     this.parser = parser
   }

--- a/server/src/tree-sitter/declarations.ts
+++ b/server/src/tree-sitter/declarations.ts
@@ -80,7 +80,7 @@ export const getEmbeddedRegionsFromNode = (tree: Parser.Tree, uri: string): Embe
         bashRegions.push(symbol)
       }
       return false
-    } else if (TreeSitterUtil.isPythonDefinition(node)) {
+    } else if (TreeSitterUtil.isPythonDefinition(node) || TreeSitterUtil.isInlinePython(node)) {
       const symbol = nodeToSymbolInformation({ node, uri })
       if (symbol !== null) {
         pythonRegions.push(symbol)
@@ -96,7 +96,7 @@ export const getEmbeddedRegionsFromNode = (tree: Parser.Tree, uri: string): Embe
   }
 }
 
-function nodeToSymbolInformation ({
+export function nodeToSymbolInformation ({
   node,
   uri
 }: {

--- a/server/src/tree-sitter/utils.ts
+++ b/server/src/tree-sitter/utils.ts
@@ -44,12 +44,28 @@ export function isDefinition (n: SyntaxNode): boolean {
   }
 }
 
+export function isInlinePython (n: SyntaxNode): boolean {
+  return n.type === 'inline_python'
+}
+
 export function isPythonDefinition (n: SyntaxNode): boolean {
   return n.type === 'anonymous_python_function' || n.type === 'python_function_definition'
 }
 
 export function isShellDefinition (n: SyntaxNode): boolean {
   return n.type === 'function_definition'
+}
+
+export function containsInlinePython (n: SyntaxNode): boolean {
+  let contains = false
+  forEach(n, (node) => {
+    if (isInlinePython(node)) {
+      contains = true
+      return false
+    }
+    return true
+  })
+  return contains
 }
 
 export function isVariableReference (n: SyntaxNode): boolean {


### PR DESCRIPTION
This includes various new functionalities:
- Add support for inline python
- Handle imports of 'bb', 'd', 'e' and 'os'
- Fix some syntaxes that were not handled properly

They come together because my intent was to make sure I was able to map properly the positions between the embedded language documents and the original documents, once they are heavily modified.

Unfortunately, the embedded language support is still not as smooth as I'd like to. For example, tree-sitter-bitbake has a couple of bugs that will suddenly break the parsing in many unexpected ways (https://github.com/amaanq/tree-sitter-bitbake/issues/10, https://github.com/amaanq/tree-sitter-bitbake/issues/12). It seems it will also break once in a while as I type bitbake code. These issues will be addressed later, as the mapping between the positions seems to be working properly.