### PR TITLE
Bug 13349 missing hover information

### DIFF
--- a/integration-tests/project-folder/.vscode/settings.json
+++ b/integration-tests/project-folder/.vscode/settings.json
@@ -1,6 +1,3 @@
 {
     "bitbake.loggingLevel": "debug",
-    "editor.quickSuggestions": {
-        "strings": false
-    },
 }

--- a/server/src/__tests__/hover.test.ts
+++ b/server/src/__tests__/hover.test.ts
@@ -116,6 +116,26 @@ describe('on hover', () => {
     expect(shouldNotShow1).toBe(null)
     expect(shouldNotShow2).toBe(null)
     expect(shouldNotShow3).toBe(null)
+
+    // With Yocto variables present, the yocto variables should be shown in case of the duplicated variable names
+    bitBakeDocScanner.parseYoctoVariablesFile()
+
+    const shouldShow4 = await onHoverHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 1,
+        character: 1
+      }
+    })
+
+    expect(shouldShow4).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: '**DESCRIPTION**\n___\n   The package description used by package managers. If not set,\n   `DESCRIPTION` takes the value of the `SUMMARY`\n   variable.\n\n'
+      }
+    })
   })
 
   it('should show hover definition for variable flags after scanning the docs', async () => {

--- a/server/src/connectionHandlers/onHover.ts
+++ b/server/src/connectionHandlers/onHover.ts
@@ -19,7 +19,11 @@ export async function onHoverHandler (params: HoverParams): Promise<Hover | null
   // Triggers on global declaration expressions like "VAR = 'foo'" and inside variable expansion like "FOO = ${VAR}" but skip the ones like "python VAR(){}"
   const canShowHoverDefinitionForVariableName: boolean = (analyzer.getGlobalDeclarationSymbols(textDocument.uri).some((symbol) => symbol.name === word) && analyzer.isIdentifierOfVariableAssignment(params)) || analyzer.isVariableExpansion(textDocument.uri, position.line, position.character)
   if (canShowHoverDefinitionForVariableName) {
-    const found = bitBakeDocScanner.bitbakeVariableInfo.find((item) => item.name === word)
+    const found = [
+      ...bitBakeDocScanner.bitbakeVariableInfo.filter((bitbakeVariable) => !bitBakeDocScanner.yoctoVariableInfo.some(yoctoVariable => yoctoVariable.name === bitbakeVariable.name)),
+      ...bitBakeDocScanner.yoctoVariableInfo
+    ].find((item) => item.name === word)
+
     if (found === undefined) {
       logger.debug(`[onHover] Not a bitbake variable: ${word}`)
       return null


### PR DESCRIPTION
The hover definition should show for Yocto variables and should show the one for Yocto in case of duplicate variable names.