### PR TITLE
Fix: Middlewares also expect null regions

### DIFF
--- a/client/src/language/middlewareCompletion.ts
+++ b/client/src/language/middlewareCompletion.ts
@@ -11,7 +11,7 @@ import { getEmbeddedLanguageDocPosition } from './utils'
 
 export const middlewareProvideCompletion: CompletionMiddleware['provideCompletionItem'] = async (document, position, context, token, next) => {
   const embeddedLanguageDocInfos = await requestsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), position)
-  if (embeddedLanguageDocInfos === undefined) {
+  if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
     return await next(document, position, context, token)
   }
   const adjustedPosition = await getEmbeddedLanguageDocPosition(document, embeddedLanguageDocInfos, position)

--- a/client/src/language/middlewareHover.ts
+++ b/client/src/language/middlewareHover.ts
@@ -11,7 +11,7 @@ import { getEmbeddedLanguageDocPosition } from './utils'
 
 export const middlewareProvideHover: HoverMiddleware['provideHover'] = async (document, position, token, next) => {
   const embeddedLanguageDocInfos = await requestsManager.getEmbeddedLanguageDocInfos(document.uri.toString(), position)
-  if (embeddedLanguageDocInfos === undefined) {
+  if (embeddedLanguageDocInfos === undefined || embeddedLanguageDocInfos === null) {
     return await next(document, position, token)
   }
   const adjustedPosition = await getEmbeddedLanguageDocPosition(document, embeddedLanguageDocInfos, position)

--- a/client/src/lib/src/types/requests.ts
+++ b/client/src/lib/src/types/requests.ts
@@ -19,7 +19,7 @@ export interface RequestParams {
 }
 
 export interface RequestResult {
-  [RequestType.EmbeddedLanguageDocInfos]: Promise<EmbeddedLanguageDocInfos | undefined>
+  [RequestType.EmbeddedLanguageDocInfos]: Promise<EmbeddedLanguageDocInfos | undefined | null> // for unknown reasons, the client receives null instead of undefined
 }
 
 interface RequestEmbeddedLanguageDocInfosParams {


### PR DESCRIPTION
The middlewares were expecting to receive `undefined` when the cursor was outside Bash or Python regions. For unknown reasons, they are receiving `null`.

This fix hover and completions for regions outside of Bash and Python regions (sorry I broke it). For unknown reasons, this also fix completion inside Python regions (it was still working for bash regions, and hover was still working for both).