### PR TITLE
File icon

### DIFF
--- a/client/images/yocto-file-icon.svg
+++ b/client/images/yocto-file-icon.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="63.999"
+   height="66.819"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="yocto.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="11.703258"
+     inkscape:cx="31.999636"
+     inkscape:cy="33.708562"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
+  <g
+     stroke-width=".1"
+     id="g6"
+     style="fill:#4597d9;fill-opacity:1">
+    <path
+       d="M49 29.254a2.758 2.758 0 11-5.517 0 2.758 2.758 0 115.516 0"
+       fill="#4597d9"
+       id="path2"
+       style="fill:#4597d9;fill-opacity:1" />
+    <path
+       d="M41.558 17.277L37.539 15l-8.093 16.4L20.812 15l-4.07 2.277 10.261 19.278c-.074.183-.309.688-.705 1.524-.4.796-.814 1.593-1.25 2.39-.762 1.376-1.536 2.495-2.333 3.365-.797.906-1.611 1.628-2.447 2.173a10.77 10.77 0 01-2.603 1.25 22.98 22.98 0 01-2.665.705l1.85 3.857c.58-.074 1.354-.257 2.334-.544 1.014-.253 2.116-.744 3.313-1.467 1.193-.723 2.408-1.755 3.636-3.096 1.27-1.34 2.446-3.113 3.53-5.32l11.895-24.115"
+       fill="#fff"
+       id="path4"
+       style="fill:#4597d9;fill-opacity:1" />
+  </g>
+</svg>

--- a/client/images/yocto-file-icon.svg
+++ b/client/images/yocto-file-icon.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="63.999"
-   height="66.819"
+   width="54"
+   height="56.819"
    version="1.1"
    id="svg8"
-   sodipodi:docname="yocto.svg"
+   sodipodi:docname="yocto-file-icon.svg"
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -19,30 +19,35 @@
      borderopacity="1.0"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
+     inkscape:pagecheckerboard="true"
      showgrid="false"
      inkscape:zoom="11.703258"
-     inkscape:cx="31.999636"
-     inkscape:cy="33.708562"
+     inkscape:cx="27.043751"
+     inkscape:cy="28.667231"
      inkscape:window-width="1920"
      inkscape:window-height="1016"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg8" />
+     inkscape:current-layer="svg8"
+     fit-margin-top="10"
+     fit-margin-left="10"
+     fit-margin-right="10"
+     fit-margin-bottom="10" />
   <g
-     stroke-width=".1"
+     stroke-width="0.1"
      id="g6"
-     style="fill:#4597d9;fill-opacity:1">
+     style="fill:#4e96ba;fill-opacity:1"
+     transform="translate(-5,-5)">
     <path
-       d="M49 29.254a2.758 2.758 0 11-5.517 0 2.758 2.758 0 115.516 0"
+       d="m 49,29.254 a 2.7585,2.7585 0 1 1 -5.517,0 2.758,2.758 0 1 1 5.516,0"
        fill="#4597d9"
        id="path2"
-       style="fill:#4597d9;fill-opacity:1" />
+       style="fill:#4e96ba;fill-opacity:1" />
     <path
-       d="M41.558 17.277L37.539 15l-8.093 16.4L20.812 15l-4.07 2.277 10.261 19.278c-.074.183-.309.688-.705 1.524-.4.796-.814 1.593-1.25 2.39-.762 1.376-1.536 2.495-2.333 3.365-.797.906-1.611 1.628-2.447 2.173a10.77 10.77 0 01-2.603 1.25 22.98 22.98 0 01-2.665.705l1.85 3.857c.58-.074 1.354-.257 2.334-.544 1.014-.253 2.116-.744 3.313-1.467 1.193-.723 2.408-1.755 3.636-3.096 1.27-1.34 2.446-3.113 3.53-5.32l11.895-24.115"
+       d="M 41.558,17.277 37.539,15 29.446,31.4 20.812,15 l -4.07,2.277 10.261,19.278 c -0.074,0.183 -0.309,0.688 -0.705,1.524 -0.4,0.796 -0.814,1.593 -1.25,2.39 -0.762,1.376 -1.536,2.495 -2.333,3.365 -0.797,0.906 -1.611,1.628 -2.447,2.173 A 10.77,10.77 0 0 1 17.665,47.257 22.98,22.98 0 0 1 15,47.962 l 1.85,3.857 c 0.58,-0.074 1.354,-0.257 2.334,-0.544 1.014,-0.253 2.116,-0.744 3.313,-1.467 1.193,-0.723 2.408,-1.755 3.636,-3.096 1.27,-1.34 2.446,-3.113 3.53,-5.32 L 41.558,17.277"
        fill="#fff"
        id="path4"
-       style="fill:#4597d9;fill-opacity:1" />
+       style="fill:#4e96ba;fill-opacity:1" />
   </g>
 </svg>

--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,11 @@
           ".bbclass",
           ".conf"
         ],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "dark": "images/yocto-file-icon.svg",
+          "light": "images/yocto-file-icon.svg"
+        }
       }
     ],
     "grammars": [


### PR DESCRIPTION
Turns out there is an undocumented way of contributing language-specific default icons.
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/19970889/6cf72ed7-5cd0-4246-a140-5d6f589b0565)
 