### PR TITLE
Fix: Change working directory for relative paths settings

### DIFF
--- a/client/src/lib/src/BitbakeSettings.ts
+++ b/client/src/lib/src/BitbakeSettings.ts
@@ -12,9 +12,15 @@ export interface BitbakeSettings {
   pathToEnvScript: string
 }
 
-export function loadBitbakeSettings (settings: any, workspaceFolder: string = ''): BitbakeSettings {
+export function loadBitbakeSettings (settings: any, workspaceFolder: string): BitbakeSettings {
   /* eslint no-template-curly-in-string: "off" */
   // The default values are defined in package.json
+  // Change the working directory to properly handle relative paths in the language client
+  try {
+    process.chdir(workspaceFolder)
+  } catch (err: any) {
+    console.error(`chdir: ${err}`)
+  }
   let pathToBitbakeFolder: string = settings.pathToBitbakeFolder
   pathToBitbakeFolder = pathToBitbakeFolder.replace('${workspaceFolder}', workspaceFolder)
   pathToBitbakeFolder = path.resolve(pathToBitbakeFolder)

--- a/client/src/lib/src/__tests__/driver/bitbake-settings.test.ts
+++ b/client/src/lib/src/__tests__/driver/bitbake-settings.test.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import path from 'path'
 import { loadBitbakeSettings } from '../../BitbakeSettings'
 
 describe('BitbakeSettings Tests', () => {
@@ -18,5 +19,15 @@ describe('BitbakeSettings Tests', () => {
       pathToBuildFolder: '${workspaceFolder}/build'
     }, '/home/user/workspace')
     expect(settings.pathToBuildFolder).toEqual('/home/user/workspace/build')
+  })
+
+  it('should expand relative paths', () => {
+    const settings = loadBitbakeSettings({
+      pathToBitbakeFolder: '',
+      pathToEnvScript: '',
+      // eslint-disable-next-line no-template-curly-in-string
+      pathToBuildFolder: './build'
+    }, __dirname)
+    expect(settings.pathToBuildFolder).toEqual(path.join(__dirname, '/build'))
   })
 })


### PR DESCRIPTION
Settings like pathToBitbakeFolder should use "${workspaceFolder}" to point to relative URIs. However if the user uses a relative path like "./", the language server did resolve it properly, but not the client. We now set the working directory to the workspace folder to be consistent.

This does not produce unintended side effects according to our tests.