### PR TITLE
Chore: Add integration tests for Hover and Completion

### DIFF
--- a/integration-tests/project-folder/sources/meta-fixtures/completion.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/completion.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = 'FOO'
+
+python do_foo(){
+    print('123')
+}
+
+do_bar(){
+    echo '123'
+}

--- a/integration-tests/project-folder/sources/meta-fixtures/hover.bb
+++ b/integration-tests/project-folder/sources/meta-fixtures/hover.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = 'FOO'
+
+python do_foo(){
+    print('123')
+}
+
+do_bar(){
+    echo '123'
+}

--- a/integration-tests/src/tests/bitbake-commands.test.ts
+++ b/integration-tests/src/tests/bitbake-commands.test.ts
@@ -6,10 +6,7 @@
 import * as assert from 'assert'
 import * as vscode from 'vscode'
 import { afterEach } from 'mocha'
-
-async function delay (ms: number): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, ms))
-}
+import { delay } from '../utils/async'
 
 suite('Bitbake Commands Test Suite', () => {
   let disposables: vscode.Disposable[] = []

--- a/integration-tests/src/tests/bitbake-parse.test.ts
+++ b/integration-tests/src/tests/bitbake-parse.test.ts
@@ -9,10 +9,7 @@ import { afterEach } from 'mocha'
 
 import path from 'path'
 import { addLayer, resetLayer } from '../utils/bitbake'
-
-async function delay (ms: number): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, ms))
-}
+import { delay } from '../utils/async'
 
 suite('Bitbake Commands Test Suite', () => {
   let disposables: vscode.Disposable[] = []

--- a/integration-tests/src/tests/completion.test.ts
+++ b/integration-tests/src/tests/completion.test.ts
@@ -1,0 +1,71 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import path from 'path'
+
+async function delay (ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+suite('Bitbake Completion Test Suite', () => {
+  const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/completion.bb')
+  const docUri = vscode.Uri.parse(`file://${filePath}`)
+
+  suiteSetup(async function (this: Mocha.Context) {
+    this.timeout(100000)
+    const vscodeBitbake = vscode.extensions.getExtension('yocto-project.yocto-bitbake')
+    if (vscodeBitbake === undefined) {
+      assert.fail('Bitbake extension is not available')
+    }
+    await vscodeBitbake.activate()
+    await vscode.workspace.openTextDocument(docUri)
+  })
+
+  const checkHasItemWithLabel = (completionList: vscode.CompletionList, label: string): boolean => {
+    return completionList.items.some(item => {
+      if (typeof item.label === 'string') {
+        return item.label === label
+      }
+      return item.label.label === label
+    })
+  }
+
+  const testCompletion = async (position: vscode.Position, expected: string): Promise<void> => {
+    let completionList: vscode.CompletionList = { items: [] }
+    while (!checkHasItemWithLabel(completionList, expected)) {
+      completionList = await vscode.commands.executeCommand<vscode.CompletionList>(
+        'vscode.executeCompletionItemProvider',
+        docUri,
+        position
+      )
+      // For completion to work, an "embedded language document" needs to be generated.
+      // We have no practical way to know when it will be done.
+      // Attempts to wait for the "embedded language document" to be created in its folder still produced incorrect results.
+      // So here we are, just hoping everything is fine so our test won't take forever to fail.
+      await delay(100)
+    }
+    assert.strictEqual(checkHasItemWithLabel(completionList, expected), true)
+  }
+
+  test('Completion appears properly on bitbake variable', async () => {
+    const position = new vscode.Position(0, 2)
+    const expected = 'DESCRIPTION'
+    await testCompletion(position, expected)
+  }).timeout(300000)
+
+  test('Completion appears properly on embedded python', async () => {
+    const position = new vscode.Position(3, 6)
+    const expected = 'print'
+    await testCompletion(position, expected)
+  }).timeout(300000)
+
+  test('Completion appears properly on embedded bash', async () => {
+    const position = new vscode.Position(7, 6)
+    const expected = 'echo'
+    await testCompletion(position, expected)
+  }).timeout(300000)
+})

--- a/integration-tests/src/tests/completion.test.ts
+++ b/integration-tests/src/tests/completion.test.ts
@@ -6,10 +6,7 @@
 import * as assert from 'assert'
 import * as vscode from 'vscode'
 import path from 'path'
-
-async function delay (ms: number): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, ms))
-}
+import { delay } from '../utils/async'
 
 suite('Bitbake Completion Test Suite', () => {
   const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/completion.bb')

--- a/integration-tests/src/tests/hover.test.ts
+++ b/integration-tests/src/tests/hover.test.ts
@@ -1,0 +1,68 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import path from 'path'
+
+async function delay (ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+suite('Bitbake Hover Test Suite', () => {
+  const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/hover.bb')
+  const docUri = vscode.Uri.parse(`file://${filePath}`)
+
+  suiteSetup(async function (this: Mocha.Context) {
+    this.timeout(100000)
+    const vscodeBitbake = vscode.extensions.getExtension('yocto-project.yocto-bitbake')
+    if (vscodeBitbake === undefined) {
+      assert.fail('Bitbake extension is not available')
+    }
+    await vscodeBitbake.activate()
+    await vscode.workspace.openTextDocument(docUri)
+  })
+
+  const testHover = async (position: vscode.Position, expected: string): Promise<void> => {
+    let hoverResult: vscode.Hover[] = []
+    while (hoverResult.length === 0) {
+      hoverResult = await vscode.commands.executeCommand<vscode.Hover[]>(
+        'vscode.executeHoverProvider',
+        docUri,
+        position
+      )
+      // For hover to work, an "embedded language document" needs to be generated.
+      // We have no practical way to know when it will be done.
+      // Attempts to wait for the "embedded language document" to be created in its folder still produced incorrect results.
+      // So here we are, just hoping everything is fine so our test won't take forever to fail.
+      await delay(100)
+    }
+
+    assert.strictEqual(hoverResult.length, 1)
+    const content = hoverResult[0]?.contents[0]
+    if (!(content instanceof vscode.MarkdownString)) {
+      assert.fail('content is not a MarkdownString')
+    }
+    assert.strictEqual(content.value.includes(expected), true)
+  }
+
+  test('Hover appears properly on bitbake variable', async () => {
+    const position = new vscode.Position(0, 2)
+    const expected = 'The package description used by package managers'
+    await testHover(position, expected)
+  }).timeout(300000)
+
+  test('Hover appears properly on embedded python', async () => {
+    const position = new vscode.Position(3, 6)
+    const expected = 'def print'
+    await testHover(position, expected)
+  }).timeout(300000)
+
+  test('Hover appears properly on embedded bash', async () => {
+    const position = new vscode.Position(7, 6)
+    const expected = 'echo'
+    await testHover(position, expected)
+  }).timeout(300000)
+})

--- a/integration-tests/src/tests/hover.test.ts
+++ b/integration-tests/src/tests/hover.test.ts
@@ -6,10 +6,7 @@
 import * as assert from 'assert'
 import * as vscode from 'vscode'
 import path from 'path'
-
-async function delay (ms: number): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, ms))
-}
+import { delay } from '../utils/async'
 
 suite('Bitbake Hover Test Suite', () => {
   const filePath = path.resolve(__dirname, '../../project-folder/sources/meta-fixtures/hover.bb')

--- a/integration-tests/src/tests/vscode-integration.test.ts
+++ b/integration-tests/src/tests/vscode-integration.test.ts
@@ -6,10 +6,7 @@
 import * as assert from 'assert'
 import { after } from 'mocha'
 import * as vscode from 'vscode'
-
-async function delay (ms: number): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, ms))
-}
+import { delay } from '../utils/async'
 
 suite('VSCode integration Test Suite', () => {
   suiteSetup(async function (this: Mocha.Context) {

--- a/integration-tests/src/utils/async.ts
+++ b/integration-tests/src/utils/async.ts
@@ -1,0 +1,8 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2023 Savoir-faire Linux. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export async function delay (ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     "ts"
   ],
   modulePathIgnorePatterns: [
+    "<rootDir>/.vscode-test",
     "<rootDir>/client/server",
     "<rootDir>/integration-tests",
     "<rootDir>/client/out"


### PR DESCRIPTION
So this adds integration tests for "completion" and "hover". Unfortunately, I've been unable to properly wait for the setup to complete, so it has some horrible waitings.

Note that I've set the vscode version to 1.84.2 and added two extensions.