### PR TITLE
Fix: Disable bitbake error popup per workspace instead of globally

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -55,7 +55,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 
   taskProvider = vscode.tasks.registerTaskProvider('bitbake', bitbakeTaskProvider)
 
-  const notificationManager = new ClientNotificationManager(client, context.globalState)
+  const notificationManager = new ClientNotificationManager(client, context.workspaceState)
   context.subscriptions.push(...notificationManager.buildHandlers())
   const bitBakeProjectScannerClient = new BitBakeProjectScannerClient(client)
   context.subscriptions.push(...bitBakeProjectScannerClient.buildHandlers())


### PR DESCRIPTION
The user may want to disable the bitbake error popup for a specific workspace but he should be reminded of the error popup when he opens another workspace.