### PR TITLE
Docker wrapper support

### DIFF
--- a/client/src/lib/src/BitbakeDriver.ts
+++ b/client/src/lib/src/BitbakeDriver.ts
@@ -56,13 +56,13 @@ export class BitbakeDriver {
     let script = ''
 
     if (this.bitbakeSettings.commandWrapper !== undefined) {
-      script += sanitizeForShell(this.bitbakeSettings.commandWrapper) + " '"
+      script += this.bitbakeSettings.commandWrapper + " '"
     }
 
     if (this.bitbakeSettings.pathToEnvScript !== undefined) {
-      script += `. ${sanitizeForShell(this.bitbakeSettings.pathToEnvScript)} ${sanitizeForShell(this.bitbakeSettings.pathToBuildFolder)} && `
+      script += `. ${this.bitbakeSettings.pathToEnvScript} ${this.bitbakeSettings.pathToBuildFolder} && `
     }
-    script += sanitizeForShell(command)
+    script += command
 
     if (this.bitbakeSettings.commandWrapper !== undefined) {
       script += "'"
@@ -70,12 +70,4 @@ export class BitbakeDriver {
 
     return script
   }
-}
-
-/// Santitize a string to be passed in a shell command (remove special characters)
-function sanitizeForShell (command: string | undefined): string {
-  if (command === undefined) {
-    return ''
-  }
-  return command.replace(/[;`&|<>\\$(){}!#*?"']/g, '')
 }

--- a/client/src/lib/src/BitbakeDriver.ts
+++ b/client/src/lib/src/BitbakeDriver.ts
@@ -60,7 +60,11 @@ export class BitbakeDriver {
     }
 
     if (this.bitbakeSettings.pathToEnvScript !== undefined) {
-      script += `. ${this.bitbakeSettings.pathToEnvScript} ${this.bitbakeSettings.pathToBuildFolder} && `
+      script += `. ${this.bitbakeSettings.pathToEnvScript}`
+      if (this.bitbakeSettings.pathToBuildFolder !== undefined) {
+        script += ` ${this.bitbakeSettings.pathToBuildFolder}`
+      }
+      script += ' && '
     }
     script += command
 

--- a/client/src/lib/src/BitbakeSettings.ts
+++ b/client/src/lib/src/BitbakeSettings.ts
@@ -38,5 +38,13 @@ function resolveSettingsPath (configurationPath: string, workspaceFolder: string
 }
 
 function expandWorkspaceFolder (configuration: string, workspaceFolder: string): string {
-  return configuration.replace(/\${workspaceFolder}/g, workspaceFolder)
+  return sanitizeForShell(configuration.replace(/\${workspaceFolder}/g, workspaceFolder)) as string
+}
+
+/// Santitize a string to be passed in a shell command (remove special characters)
+function sanitizeForShell (command: string | undefined): string | undefined {
+  if (command === undefined) {
+    return undefined
+  }
+  return command.replace(/[;`&|<>\\$(){}!#*?"']/g, '')
 }

--- a/client/src/lib/src/__tests__/driver/bitbake-driver.test.ts
+++ b/client/src/lib/src/__tests__/driver/bitbake-driver.test.ts
@@ -9,15 +9,16 @@ import { BitbakeDriver } from '../../BitbakeDriver'
 describe('BitbakeDriver Tests', () => {
   it('should protect from shell injections', (done) => {
     const driver = new BitbakeDriver()
-    const process = driver.spawnBitbakeProcess(': ; printenv')
-    process.stdout?.on('data', (data) => {
-      if (data.toString().includes('USER=') === true) {
-        done('Command injection detected')
-      }
-    })
-    process.on('exit', (code) => {
-      expect(code).not.toBe(0)
-      done()
+    driver.spawnBitbakeProcess(': ; printenv').then((process) => {
+      process.stdout?.on('data', (data) => {
+        if (data.toString().includes('USER=') === true) {
+          done('Command injection detected')
+        }
+      })
+      process.on('exit', (code) => {
+        expect(code).not.toBe(0)
+        done()
+      })
     })
   })
 
@@ -38,11 +39,12 @@ describe('BitbakeDriver Tests', () => {
     const content = 'cd ' + fakeBuildPath + '; echo FINDME'
     fs.writeFileSync(fakeEnvScriptPath, content)
 
-    const process = driver.spawnBitbakeProcess(':')
-    process.stdout?.on('data', (data) => {
-      if (data.includes('FINDME') === true) {
-        done()
-      }
+    driver.spawnBitbakeProcess(':').then((process) => {
+      process.stdout?.on('data', (data) => {
+        if (data.includes('FINDME') === true) {
+          done()
+        }
+      })
     })
   })
 
@@ -72,6 +74,6 @@ describe('BitbakeDriver Tests', () => {
     }, '/home/user/yocto')
 
     const script = driver.composeBitbakeScript('bitbake busybox')
-    expect(script).toEqual(expect.stringContaining("docker run --rm -it -v /home/user/yocto:/workdir crops/poky --workdir=/workdir /bin/bash -c '. /home/user/yocto/poky/oe-init-build-env  && bitbake busybox'"))
+    expect(script).toEqual(expect.stringContaining("docker run --rm -it -v /home/user/yocto:/workdir crops/poky --workdir=/workdir /bin/bash -c '. /home/user/yocto/poky/oe-init-build-env && bitbake busybox'"))
   })
 })

--- a/client/src/lib/src/__tests__/driver/bitbake-driver.test.ts
+++ b/client/src/lib/src/__tests__/driver/bitbake-driver.test.ts
@@ -9,7 +9,7 @@ import { BitbakeDriver } from '../../BitbakeDriver'
 describe('BitbakeDriver Tests', () => {
   it('should protect from shell injections', (done) => {
     const driver = new BitbakeDriver()
-    driver.spawnBitbakeProcess(': ; printenv').then((process) => {
+    void driver.spawnBitbakeProcess(': ; printenv').then((process) => {
       process.stdout?.on('data', (data) => {
         if (data.toString().includes('USER=') === true) {
           done('Command injection detected')
@@ -39,7 +39,7 @@ describe('BitbakeDriver Tests', () => {
     const content = 'cd ' + fakeBuildPath + '; echo FINDME'
     fs.writeFileSync(fakeEnvScriptPath, content)
 
-    driver.spawnBitbakeProcess(':').then((process) => {
+    void driver.spawnBitbakeProcess(':').then((process) => {
       process.stdout?.on('data', (data) => {
         if (data.includes('FINDME') === true) {
           done()

--- a/integration-tests/project-folder/.vscode/settings.json
+++ b/integration-tests/project-folder/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "bitbake.loggingLevel": "debug",
     "bitbake.pathToBitbakeFolder": "${workspaceFolder}/sources/poky/bitbake",
-    "bitbake.pathToEnvScript": "${workspaceFolder}/sources/poky/oe-init-build-env"
+    "bitbake.pathToEnvScript": "${workspaceFolder}/sources/poky/oe-init-build-env",
+    "bitbake.pathToBuildFolder": "${workspaceFolder}/build"
 }

--- a/server/src/BitBakeProjectScanner.ts
+++ b/server/src/BitBakeProjectScanner.ts
@@ -352,6 +352,7 @@ export class BitBakeProjectScanner {
   }
 
   private async executeBitBakeCommand (command: string): Promise<childProcess.SpawnSyncReturns<Buffer>> {
+    // eslint-disable-next-line @typescript-eslint/return-await
     return this._bitbakeDriver.spawnBitbakeProcessSync(command)
   }
 }

--- a/server/src/BitBakeProjectScanner.ts
+++ b/server/src/BitBakeProjectScanner.ts
@@ -91,7 +91,7 @@ export class BitBakeProjectScanner {
   }
 
   rescanProject (): void {
-    logger.info(`request rescanProject ${this._bitbakeDriver.bitbakeSettings.pathToBuildFolder}`)
+    logger.info('request rescanProject')
 
     if (!this._scanStatus.scanIsRunning) {
       this._scanStatus.scanIsRunning = true
@@ -132,7 +132,7 @@ export class BitBakeProjectScanner {
   }
 
   private printScanStatistic (): void {
-    logger.info(`Scan results for path: ${this._bitbakeDriver.bitbakeSettings.pathToBuildFolder}`)
+    logger.info('Scan results:')
     logger.info('******************************************************************')
     logger.info(`Layer:     ${this._layers.length}`)
     logger.info(`Recipes:   ${this._recipes.length}`)

--- a/server/src/BitBakeProjectScanner.ts
+++ b/server/src/BitBakeProjectScanner.ts
@@ -99,13 +99,13 @@ export class BitBakeProjectScanner {
       void _connection?.sendNotification('bitbake/startScan')
 
       try {
-        this.parseAllRecipes()
         this.scanAvailableLayers()
         this.scanForClasses()
         this.scanForIncludeFiles()
         this.scanForRecipes()
         this.scanRecipesAppends()
         this.scanOverrides()
+        this.parseAllRecipes()
 
         logger.info('scan ready')
         this.printScanStatistic()

--- a/server/src/__tests__/scanner.test.ts
+++ b/server/src/__tests__/scanner.test.ts
@@ -12,7 +12,7 @@ const pathToEnvScript = path.join(__dirname, '../../../integration-tests/project
 const workspaceFolder = path.join(__dirname, '../../../integration-tests/project-folder')
 
 describe('BitBakeProjectScanner', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     bitBakeProjectScanner.loadSettings(
       {
         pathToBitbakeFolder,
@@ -23,8 +23,8 @@ describe('BitBakeProjectScanner', () => {
       },
       workspaceFolder
     )
-    bitBakeProjectScanner.rescanProject()
-  })
+    await bitBakeProjectScanner.rescanProject()
+  }, 300000)
 
   it('can get a list of layers', async () => {
     const layers = bitBakeProjectScanner.layers

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -93,6 +93,7 @@ async function checkBitbakeSettingsSanity (): Promise<boolean> {
     return false
   }
 
+  // eslint-disable-next-line @typescript-eslint/await-thenable
   const ret = await bitBakeProjectScanner.bitbakeDriver.spawnBitbakeProcessSync('which bitbake')
   if (ret.status !== 0) {
     serverNotificationManager.sendBitBakeSettingsError('Command "which bitbake" failed: \n' + ret.stdout.toString() + ret.stderr.toString())
@@ -102,6 +103,7 @@ async function checkBitbakeSettingsSanity (): Promise<boolean> {
   return true
 }
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 connection.onDidChangeConfiguration(async (change) => {
   logger.level = change.settings.bitbake.loggingLevel
   bitBakeProjectScanner.loadSettings(change.settings.bitbake, workspaceRoot)
@@ -111,6 +113,7 @@ connection.onDidChangeConfiguration(async (change) => {
   parseOnSave = change.settings.bitbake.parseOnSave
 })
 
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 connection.onDidChangeWatchedFiles(async (change) => {
   logger.debug(`onDidChangeWatchedFiles: ${JSON.stringify(change)}`)
   change.changes?.forEach((change) => {


### PR DESCRIPTION
Calling bitbake through a docker commandWrapper is possible except we get broken pipe errors because of the way the bitbake server forks. This PR refactors the way we call bitbake in order to serialize them.