### PR TITLE
Fix incorrect highlight on escaped quotes outside the strings

### DIFF
--- a/client/syntaxes/bitbake.tmLanguage.json
+++ b/client/syntaxes/bitbake.tmLanguage.json
@@ -10,6 +10,12 @@
     ],
     "patterns": [
         {
+            "include": "#escaped-single-quote"
+        },
+        {
+            "include": "#escaped-double-quote"
+        },
+        {
             "include": "#string"
         },
         {
@@ -100,8 +106,7 @@
                     "end": "(\")",
                     "patterns": [
                         {
-                            "match": "\\\\\"",
-                            "name": "constant.character.escape.bb"
+                            "include": "#escaped-double-quote"
                         },
                         {
                             "include": "#inline-python"
@@ -117,8 +122,7 @@
                     "end": "(')",
                     "patterns": [
                         {
-                            "match": "\\\\'",
-                            "name": "constant.character.escape.bb"
+                            "include": "#escaped-single-quote"
                         },
                         {
                             "include": "#inline-python"
@@ -251,6 +255,14 @@
         "parenthesis-close": {
             "match": "\\)",
             "name": "meta.embedded.parenthesis.close.bb"
+        },
+        "escaped-single-quote":{
+            "match": "\\\\'",
+            "name": "constant.character.escape.bb"
+        },
+        "escaped-double-quote":{
+            "match": "\\\\\"",
+            "name": "constant.character.escape.bb"
         }
     }
 }

--- a/client/test/grammars/snaps/strings.bb
+++ b/client/test/grammars/snaps/strings.bb
@@ -30,6 +30,9 @@ export ENV_VARIABLE = "variable-value"
 
 do_foo() {
   bbplain "$ENV_VARIABLE"
+  ACLOCAL="aclocal"
+  bbnote Executing ACLOCAL=\"$ACLOCAL\"
+  bbnote Executing ACLOCAL=\'$ACLOCAL\'
 }
 
 KERNEL_FEATURES:append:qemux86-64=" cfg/sound.scc cfg/paravirt_kvm.scc" 

--- a/client/test/grammars/test-cases/strings.bb
+++ b/client/test/grammars/test-cases/strings.bb
@@ -84,6 +84,13 @@
 #          ^ source.bb string.quoted.double.bb
 #           ^^^^^^^^^^^^^ source.bb string.quoted.double.bb
 #                        ^ source.bb string.quoted.double.bb
+>  ACLOCAL="aclocal"
+>  bbnote Executing ACLOCAL=\"$ACLOCAL\"
+#                           ^^ source.bb constant.character.escape.bb
+#                                     ^^ source.bb constant.character.escape.bb
+>  bbnote Executing ACLOCAL=\'$ACLOCAL\'
+#                           ^^ source.bb constant.character.escape.bb
+#                                     ^^ source.bb constant.character.escape.bb
 >}
  
 >KERNEL_FEATURES:append:qemux86-64=" cfg/sound.scc cfg/paravirt_kvm.scc"


### PR DESCRIPTION
Before:
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/5b05a328-79c8-428b-8986-d52d7531f8de)
After:
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/6fb3f22a-4998-4b46-a27a-0159aa314750)
