### PR TITLE
Implement and optimize symbol scanner in Analyzer

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -5,10 +5,8 @@
 
 import { generateParser } from '../tree-sitter/parser'
 import Analyzer from '../tree-sitter/analyzer'
-import { FIXTURE_DOCUMENT } from './fixtures/fixtures'
-
+import { FIXTURE_DOCUMENT, DUMMY_URI } from './fixtures/fixtures'
 // Needed as the param
-const DUMMY_URI = 'dummy_uri'
 
 async function getAnalyzer (): Promise<Analyzer> {
   const parser = await generateParser()

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -6,7 +6,7 @@
 import { generateParser } from '../tree-sitter/parser'
 import Analyzer from '../tree-sitter/analyzer'
 import { FIXTURE_DOCUMENT, DUMMY_URI, FIXTURE_URI } from './fixtures/fixtures'
-import { bitBakeProjectScanner } from '../BitBakeProjectScanner'
+import { bitBakeProjectScannerClient } from '../BitbakeProjectScannerClient'
 import path from 'path'
 import fs from 'fs'
 import { logger } from '../lib/src/utils/OutputLogger'
@@ -122,7 +122,7 @@ describe('getDirectiveFileUris', () => {
     const parsedFooPath = path.parse(FIXTURE_DOCUMENT.FOO_INC.uri.replace('file://', ''))
     const parsedBazPath = path.parse(FIXTURE_DOCUMENT.BAZ_BBCLASS.uri.replace('file://', ''))
 
-    jest.spyOn(bitBakeProjectScanner, 'includes', 'get').mockReturnValue([
+    bitBakeProjectScannerClient.bitbakeScanResult._includes = [
       {
         name: parsedBarPath.name,
         path: parsedBarPath,
@@ -133,13 +133,13 @@ describe('getDirectiveFileUris', () => {
         path: parsedFooPath,
         extraInfo: 'layer: core'
       }
-    ])
+    ]
 
-    jest.spyOn(bitBakeProjectScanner, 'classes', 'get').mockReturnValue([{
+    bitBakeProjectScannerClient.bitbakeScanResult._classes = [{
       name: parsedBazPath.name,
       path: parsedBazPath,
       extraInfo: 'layer: core'
-    }])
+    }]
 
     const parser = await generateParser()
     const analyzer = await getAnalyzer()

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -116,6 +116,25 @@ describe('On Completion', () => {
         }
       ])
     )
+    // Duplicate variables from bitbake docs should not be included
+    expect(resultAfterDocScan).not.toEqual(
+      expect.arrayContaining([
+        {
+          documentation: {
+            value: '```man\nDESCRIPTION (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   A long description for the recipe.\n\n\n[Reference](https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-ref-variables.html#term-DESCRIPTION)',
+            kind: 'markdown'
+          },
+          labelDetails: {
+            description: 'Source: Bitbake'
+          },
+          insertText: undefined,
+          insertTextFormat: 1,
+          label: 'DESCRIPTION',
+          kind: 6
+        }
+      ])
+    )
+
     // Variables from bitbake docs after filtering the duplicates
     expect(resultAfterDocScan).toEqual(
       expect.arrayContaining([

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -5,12 +5,10 @@
 
 import { onCompletionHandler } from '../connectionHandlers/onCompletion'
 import { analyzer } from '../tree-sitter/analyzer'
-import { FIXTURE_DOCUMENT } from './fixtures/fixtures'
+import { FIXTURE_DOCUMENT, DUMMY_URI } from './fixtures/fixtures'
 import { generateParser } from '../tree-sitter/parser'
 import { bitBakeDocScanner } from '../BitBakeDocScanner'
 import { bitBakeProjectScannerClient } from '../BitbakeProjectScannerClient'
-
-const DUMMY_URI = 'dummy_uri'
 
 /**
  * The onCompletion handler doesn't allow other parameters, so we can't pass the analyzer and therefore the same

--- a/server/src/__tests__/completions.test.ts
+++ b/server/src/__tests__/completions.test.ts
@@ -680,5 +680,51 @@ describe('On Completion', () => {
         })
       ])
     )
+    bitBakeDocScanner.parseBitbakeVariablesFile()
+    bitBakeDocScanner.parseYoctoVariablesFile()
+
+    const result2 = onCompletionHandler({
+      textDocument: {
+        uri: FIXTURE_URI.DIRECTIVE
+      },
+      position: {
+        line: 0,
+        character: 0
+      }
+    })
+    // When it is a variable existing in the docs, the completion item should have documentation etc.
+    expect(result2).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'DESCRIPTION',
+          labelDetails: {
+            description: path.relative(FIXTURE_URI.DIRECTIVE.replace('file://', ''), FIXTURE_URI.BAZ_BBCLASS.replace('file://', ''))
+          },
+          documentation: {
+            value: '```man\nDESCRIPTION (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   The package description used by package managers. If not set,\n   `DESCRIPTION` takes the value of the `SUMMARY`\n   variable.\n\n\n[Reference](https://docs.yoctoproject.org/ref-manual/variables.html#term-DESCRIPTION)',
+            kind: 'markdown'
+          },
+          insertText: undefined,
+          insertTextFormat: 1
+        })
+      ])
+    )
+    // The variables from docs should be filtered out if they exist in the extra symbols
+    expect(result2).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'DESCRIPTION',
+          labelDetails: {
+            description: 'Source: Yocto'
+          },
+          documentation: {
+            value: '```man\nDESCRIPTION (bitbake-language-server)\n\n\n```\n```bitbake\n\n```\n---\n   The package description used by package managers. If not set,\n   `DESCRIPTION` takes the value of the `SUMMARY`\n   variable.\n\n\n[Reference](https://docs.yoctoproject.org/ref-manual/variables.html#term-DESCRIPTION)',
+            kind: 'markdown'
+          },
+          insertText: undefined,
+          insertTextFormat: 1
+        })
+      ])
+    )
   })
 })

--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -6,9 +6,11 @@
 import { analyzer } from '../tree-sitter/analyzer'
 import { generateParser } from '../tree-sitter/parser'
 import { onDefinitionHandler } from '../connectionHandlers/onDefinition'
-import { FIXTURE_DOCUMENT, DUMMY_URI } from './fixtures/fixtures'
+import { FIXTURE_DOCUMENT, DUMMY_URI, FIXTURE_URI } from './fixtures/fixtures'
 import { type Location } from 'vscode-languageserver'
 import { definitionProvider } from '../DefinitionProvider'
+import path from 'path'
+import { bitBakeProjectScannerClient } from '../BitbakeProjectScannerClient'
 // TODO: Current implementation of the definitionProvider needs to be improved, this test suite should be modified accordingly after
 const mockDefinition = (path: string | undefined): void => {
   if (path !== undefined) {
@@ -82,5 +84,74 @@ describe('on definition', () => {
     })
 
     expect(definition2).toEqual([])
+  })
+
+  it('provides go to definition for variables if the included files also contain the variable', async () => {
+    const parsedBazPath = path.parse(FIXTURE_DOCUMENT.BAZ_BBCLASS.uri.replace('file://', ''))
+    const parsedFooPath = path.parse(FIXTURE_DOCUMENT.FOO_INC.uri.replace('file://', ''))
+
+    bitBakeProjectScannerClient.bitbakeScanResult = {
+      _layers: [],
+      _overrides: [],
+      _classes: [{
+        name: parsedBazPath.name,
+        path: parsedBazPath,
+        extraInfo: 'layer: core'
+      }],
+      _recipes: [],
+      _includes: [
+        {
+          name: parsedFooPath.name,
+          path: parsedFooPath,
+          extraInfo: 'layer: core'
+        }
+      ]
+    }
+
+    await analyzer.analyze({
+      uri: DUMMY_URI,
+      document: FIXTURE_DOCUMENT.DEFINITION
+    })
+
+    const result = onDefinitionHandler({
+      textDocument: {
+        uri: DUMMY_URI
+      },
+      position: {
+        line: 10,
+        character: 1
+      }
+    })
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          uri: FIXTURE_URI.BAZ_BBCLASS,
+          range: {
+            start: {
+              line: 0,
+              character: 0
+            },
+            end: {
+              line: 0,
+              character: 27
+            }
+          }
+        },
+        {
+          uri: FIXTURE_URI.FOO_INC,
+          range: {
+            start: {
+              line: 0,
+              character: 0
+            },
+            end: {
+              line: 0,
+              character: 23
+            }
+          }
+        }
+      ])
+    )
   })
 })

--- a/server/src/__tests__/definition.test.ts
+++ b/server/src/__tests__/definition.test.ts
@@ -6,7 +6,7 @@
 import { analyzer } from '../tree-sitter/analyzer'
 import { generateParser } from '../tree-sitter/parser'
 import { onDefinitionHandler } from '../connectionHandlers/onDefinition'
-import { FIXTURE_DOCUMENT } from './fixtures/fixtures'
+import { FIXTURE_DOCUMENT, DUMMY_URI } from './fixtures/fixtures'
 import { type Location } from 'vscode-languageserver'
 import { definitionProvider } from '../DefinitionProvider'
 // TODO: Current implementation of the definitionProvider needs to be improved, this test suite should be modified accordingly after
@@ -20,7 +20,6 @@ const mockDefinition = (path: string | undefined): void => {
   }
 }
 
-const DUMMY_URI = 'dummy_uri'
 describe('on definition', () => {
   beforeAll(async () => {
     if (!analyzer.hasParser()) {

--- a/server/src/__tests__/fixtures/bbclass/baz.bbclass
+++ b/server/src/__tests__/fixtures/bbclass/baz.bbclass
@@ -1,0 +1,1 @@
+DESCRIPTION = 'baz.bbclass'

--- a/server/src/__tests__/fixtures/definition.bb
+++ b/server/src/__tests__/fixtures/definition.bb
@@ -3,3 +3,9 @@ inherit dummy
 require dummy.inc
 
 include dummy.inc
+
+inherit baz # This is a real file in fixture folder
+
+include inc/foo.inc
+
+DESCRIPTION = 'Go to definition for this variable should point to its included files'

--- a/server/src/__tests__/fixtures/directive.bb
+++ b/server/src/__tests__/fixtures/directive.bb
@@ -1,0 +1,3 @@
+require inc/foo.inc
+include inc/bar.inc
+inherit baz  

--- a/server/src/__tests__/fixtures/fixtures.ts
+++ b/server/src/__tests__/fixtures/fixtures.ts
@@ -32,7 +32,11 @@ export const FIXTURE_URI = {
   HOVER: `file://${path.join(FIXTURE_FOLDER, 'hover.bb')}`,
   DEFINITION: `file://${path.join(FIXTURE_FOLDER, 'definition.bb')}`,
   EMBEDDED: `file://${path.join(FIXTURE_FOLDER, 'embedded.bb')}`,
-  SEMANTIC_TOKENS: `file://${path.join(FIXTURE_FOLDER, 'semanticTokens.bb')}`
+  SEMANTIC_TOKENS: `file://${path.join(FIXTURE_FOLDER, 'semanticTokens.bb')}`,
+  DIRECTIVE: `file://${path.join(FIXTURE_FOLDER, 'directive.bb')}`,
+  BAZ_BBCLASS: `file://${path.join(FIXTURE_FOLDER, 'bbclass', 'baz.bbclass')}`,
+  BAR_INC: `file://${path.join(FIXTURE_FOLDER, 'inc', 'bar.inc')}`,
+  FOO_INC: `file://${path.join(FIXTURE_FOLDER, 'inc', 'foo.inc')}`
 }
 
 export const FIXTURE_DOCUMENT: Record<FIXTURE_URI_KEY, TextDocument> = (

--- a/server/src/__tests__/fixtures/fixtures.ts
+++ b/server/src/__tests__/fixtures/fixtures.ts
@@ -41,3 +41,5 @@ export const FIXTURE_DOCUMENT: Record<FIXTURE_URI_KEY, TextDocument> = (
   acc[cur] = getDocument(FIXTURE_URI[cur])
   return acc
 }, {})
+
+export const DUMMY_URI = 'file://dummy_uri.bb'

--- a/server/src/__tests__/fixtures/inc/bar.inc
+++ b/server/src/__tests__/fixtures/inc/bar.inc
@@ -1,0 +1,2 @@
+DESCRIPTION = 'bar.inc'
+export PYTHON = 'python3'

--- a/server/src/__tests__/fixtures/inc/foo.inc
+++ b/server/src/__tests__/fixtures/inc/foo.inc
@@ -1,0 +1,1 @@
+DESCRIPTION = 'foo.inc'

--- a/server/src/__tests__/hover.test.ts
+++ b/server/src/__tests__/hover.test.ts
@@ -6,10 +6,8 @@
 import { bitBakeDocScanner } from '../BitBakeDocScanner'
 import { analyzer } from '../tree-sitter/analyzer'
 import { generateParser } from '../tree-sitter/parser'
-import { FIXTURE_DOCUMENT } from './fixtures/fixtures'
+import { FIXTURE_DOCUMENT, DUMMY_URI } from './fixtures/fixtures'
 import { onHoverHandler } from '../connectionHandlers/onHover'
-
-const DUMMY_URI = 'dummy_uri'
 
 describe('on hover', () => {
   beforeAll(async () => {

--- a/server/src/__tests__/semanticTokens.test.ts
+++ b/server/src/__tests__/semanticTokens.test.ts
@@ -6,9 +6,7 @@
 import { analyzer } from '../tree-sitter/analyzer'
 import { generateParser } from '../tree-sitter/parser'
 import { getParsedTokens, TOKEN_LEGEND } from '../semanticTokens'
-import { FIXTURE_DOCUMENT } from './fixtures/fixtures'
-
-const DUMMY_URI = 'dummy_uri'
+import { FIXTURE_DOCUMENT, DUMMY_URI } from './fixtures/fixtures'
 
 describe('Semantic tokens', () => {
   beforeAll(async () => {

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -26,7 +26,7 @@ let documentUri = ''
 export function onCompletionHandler (textDocumentPositionParams: TextDocumentPositionParams): CompletionItem[] {
   const wordPosition = {
     line: textDocumentPositionParams.position.line,
-    // Go one character back to get completion on the current word. This is used as a parameter in descendantForPosition()
+    // Go one character back to get completion on the current word.
     character: Math.max(textDocumentPositionParams.position.character - 1, 0)
   }
 

--- a/server/src/connectionHandlers/onCompletion.ts
+++ b/server/src/connectionHandlers/onCompletion.ts
@@ -20,6 +20,7 @@ import { BITBAKE_OPERATOR } from '../completions/bitbake-operator'
 import { VARIABLE_FLAGS } from '../completions/variable-flags'
 import type { ElementInfo } from '../lib/src/types/BitbakeScanResult'
 import { bitBakeProjectScannerClient } from '../BitbakeProjectScannerClient'
+import path from 'path'
 
 let documentUri = ''
 
@@ -274,17 +275,18 @@ function getFilePath (elementInfo: ElementInfo, fileType: string): string | unde
 function convertSymbolsToCompletionItems (uri: string): CompletionItem[] {
   logger.debug(`[onCompletion] convertSymbolsToCompletionItems: ${uri}`)
   const completionItems: CompletionItem[] = []
-  analyzer.getSymbolsForUri(uri).forEach((symbol) => {
-    const completionItem: CompletionItem = {
-      label: symbol.symbolName,
-      labelDetails: {
-        description: 'Source: Symbol Scanner'
-      },
-      documentation: '',
-      data: symbol,
-      kind: CompletionItemKind.Variable
-    }
-    completionItems.push(completionItem)
+  analyzer.getExtraSymbolsForUri(uri).forEach((extraSymbols) => {
+    Object.keys(extraSymbols).forEach((key) => {
+      const completionItem: CompletionItem = {
+        label: extraSymbols[key].name,
+        labelDetails: {
+          description: path.relative(documentUri.replace('file://', ''), extraSymbols[key].location.uri.replace('file://', ''))
+        },
+        documentation: '',
+        kind: symbolKindToCompletionKind(extraSymbols[key].kind)
+      }
+      completionItems.push(completionItem)
+    })
   })
   return completionItems
 }

--- a/server/src/tree-sitter/analyzer.ts
+++ b/server/src/tree-sitter/analyzer.ts
@@ -24,8 +24,7 @@ import { type DirectiveStatementKeyword } from '../lib/src/types/directiveKeywor
 import { logger } from '../lib/src/utils/OutputLogger'
 import fs from 'fs'
 import path from 'path'
-import { bitBakeProjectScanner } from '../BitBakeProjectScanner'
-
+import { bitBakeProjectScannerClient } from '../BitbakeProjectScannerClient'
 const DEBOUNCE_TIME_MS = 500
 
 interface AnalyzedDocument {
@@ -428,7 +427,7 @@ export default class Analyzer {
         childNode.children.forEach((n) => {
           if (n.type === 'inherit_path') {
             logger.debug(`[Analyzer] Found inherit path: ${n.text}`)
-            const bbclasses = bitBakeProjectScanner.classes.filter((bbclass) => {
+            const bbclasses = bitBakeProjectScannerClient.bitbakeScanResult._classes.filter((bbclass) => {
               return bbclass.name === n.text
             })
             for (const bbclass of bbclasses) {
@@ -443,12 +442,12 @@ export default class Analyzer {
         if (childNode.firstNamedChild !== null && childNode.firstNamedChild.type === 'include_path') {
           logger.debug(`[Analyzer] Found include path: ${childNode.firstNamedChild.text}`)
           const includeFile = path.parse(childNode.firstNamedChild.text)
-          let includes = bitBakeProjectScanner.includes.filter((inc) => {
+          let includes = bitBakeProjectScannerClient.bitbakeScanResult._includes.filter((inc) => {
             return inc.name === includeFile.name
           })
 
           if (includes.length === 0) {
-            includes = bitBakeProjectScanner.recipes.filter((recipe) => {
+            includes = bitBakeProjectScannerClient.bitbakeScanResult._recipes.filter((recipe) => {
               return recipe.name === includeFile.name
             })
           }

--- a/server/src/tree-sitter/declarations.ts
+++ b/server/src/tree-sitter/declarations.ts
@@ -13,7 +13,6 @@ import type * as Parser from 'web-tree-sitter'
 import * as TreeSitterUtil from './utils'
 
 const TREE_SITTER_TYPE_TO_LSP_KIND: Record<string, LSP.SymbolKind | undefined> = {
-  environment_variable_assignment: LSP.SymbolKind.Variable,
   function_definition: LSP.SymbolKind.Function,
   python_function_definition: LSP.SymbolKind.Function,
   anonymous_python_function: LSP.SymbolKind.Function,


### PR DESCRIPTION
What `SymbolScanner` was doing:
1. Associate a new instance of it to the file when it is opened or has content changed.
2. Scan for the file in directives (**include**, **inherit** and **require**) and get the file paths, then store the file paths and their content.
3. Recursively repeat the step 2 for each file scanned.
4. When the scan is complete, Loop the stored file paths and content in step 2 to get the symbols **_(Declared variables and exported variables. e.g. `VAR = 'var'` and `export VAR = '123'`)_** using RegEx.

What I am trying to do here:
1. Without changing the goal of the original `SymbolScanner`, use the tree-sitter instead of the RegEx.
2. Move all implementations to the `analyzer`.
3. Optimized the file reading since SymbolScanner was doing a lot of the reads while the file didn't change.
4. Extract the symbols right after reading a file instead of getting all the files first and then looping each file to extract them.

How I do recursive reading on files: 
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/41dd8af1-7657-41ec-84e4-8be81e2d4533)

**Note** that the analyze action inside the sourceIncludeFiles() will invoke file read on disk. 

This PR also includes using those symbols for the completion feature.

