### PR TITLE
Fix: Handle triple quotes correctly

### DIFF
--- a/client/syntaxes/bitbake.tmLanguage.json
+++ b/client/syntaxes/bitbake.tmLanguage.json
@@ -101,6 +101,25 @@
         "string": {
             "patterns": [
                 {
+                    "name": "string.quoted.triple.bb",
+                    "begin": "(\"\"\")",
+                    "end": "(\"\"\")",
+                    "patterns": [
+                        {
+                            "include": "#escaped-single-quote"
+                        },
+                        {
+                            "include": "#escaped-double-quote"
+                        },
+                        {
+                            "include": "#inline-python"
+                        },
+                        {
+                            "include": "#variable-expansion"
+                        }
+                    ]
+                },
+                {
                     "name": "string.quoted.double.bb",
                     "begin": "(\")",
                     "end": "(\")",

--- a/client/test/grammars/snaps/strings.bb
+++ b/client/test/grammars/snaps/strings.bb
@@ -51,3 +51,9 @@ INHERIT += "autotools pkgconfig"
 MYVAR = "This string contains escaped double quote \" and it should not break the highlight"
 
 MYVAR = 'This string contains escaped single quote \' and it should not break the highlight'
+
+MYVAR = """
+nested " quotes shoudn't change the highlighting
+"""
+
+TEST_TRIPLE_QUOTES = 'the highlighting for this line which follows the triple quotes should still work correctly'

--- a/client/test/grammars/test-cases/strings.bb
+++ b/client/test/grammars/test-cases/strings.bb
@@ -143,3 +143,18 @@
 #                                                   ^^ source.bb string.quoted.single.bb constant.character.escape.bb
 #                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.single.bb
 #                                                                                           ^ source.bb string.quoted.single.bb
+
+>MYVAR = """
+#        ^^^ source.bb string.quoted.triple.bb
+>nested " quotes shoudn't change the highlighting
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.triple.bb
+>"""
+#^^^ source.bb string.quoted.triple.bb
+>
+>TEST_TRIPLE_QUOTES = 'the highlighting for this line which follows the triple quotes should still work correctly'
+#^^^^^^^^^^^^^^^^^^ source.bb variable.other.names.bb
+#                   ^ source.bb keyword.operator.bb
+#                     ^ source.bb string.quoted.single.bb
+#                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.bb string.quoted.single.bb
+#                                                                                                                ^ source.bb string.quoted.single.bb
+>


### PR DESCRIPTION
This handles the highlighting for triple quotes when the highlighting from the embedded service is not available.
![image](https://github.com/savoirfairelinux/vscode-bitbake/assets/47988425/60d8c0c7-d029-4c09-b47f-f40e7c887374)

Issue: https://github.com/yoctoproject/vscode-bitbake/issues/3